### PR TITLE
feat: add deploy contracts script

### DIFF
--- a/client/deploy-contracts/index.ts
+++ b/client/deploy-contracts/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Deploy contract to SwaySwap node.
+ */
+
+// TODO: Remove this file after `forc` enabled deploy a contract to a custom url
+// https://github.com/FuelLabs/sway/issues/1308
+import { seedWallet } from '@fuel-ts/wallet/dist/test-utils';
+import { ContractFactory, NativeAssetId, Wallet, ZeroBytes32 } from "fuels";
+import path from "path";
+import fs from "fs";
+// @ts-ignore
+import { SwayswapContractAbi__factory, TokenContractAbi__factory } from '../src/types/contracts';
+
+const tokenPath = path.join(__dirname, '../../contracts/token_contract/out/debug/token_contract.bin');
+const contractPath = path.join(__dirname, '../../contracts/swayswap_contract/out/debug/swayswap_contract.bin');
+const providerUrl = process.env.REACT_APP_FUEL_PROVIDER_URL || 'https://node.swayswap.io/graphql';
+
+export async function deployContract(contextLog: string, binaryPath: string, abi: any) {
+    console.log(contextLog, 'Create wallet...');
+    console.log(contextLog, 'connected to', providerUrl)
+    const wallet = Wallet.generate({ provider: providerUrl });
+    
+    console.log(contextLog, 'Funding wallet with some coins');
+    await seedWallet(wallet, [[5_000_000, NativeAssetId]]);
+
+    // Deploy
+    console.log(contextLog, 'Load contract binary...');
+    const bytecode = fs.readFileSync(binaryPath);
+    console.log(contextLog, 'Deploy contract...');
+    const factory = new ContractFactory(bytecode, abi, wallet);
+    const contract = await factory.deployContract(ZeroBytes32);
+
+    console.log(contextLog, 'Contract deployed...');
+    return contract;
+}
+
+(async function () {
+    try {
+        const contract = await deployContract('SwaySwap', tokenPath, TokenContractAbi__factory.abi);
+        const token = await deployContract('Token', contractPath, SwayswapContractAbi__factory.abi);
+
+        console.log('SwaySwap Contract Id', contract.id);
+        console.log('Token Contract Id', token.id);
+    } catch (err) {
+        console.error(err);
+    }
+})();

--- a/client/deploy-contracts/tsconfig.json
+++ b/client/deploy-contracts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "lib": ["es2019"],
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["./index.ts"]
+}

--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
+    "deploy-contracts": "sh ./scripts/deploy-contracts.sh",
     "build-contracts": "sh ./scripts/build-contracts.sh",
     "postinstall": "sh ./scripts/postinstall.sh",
     "start": "react-scripts start",

--- a/client/scripts/deploy-contracts.sh
+++ b/client/scripts/deploy-contracts.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Import env variables
+source .env;
+# Foward REACT_APP_FUEL_PROVIDER_URL to the deploy execution
+REACT_APP_FUEL_PROVIDER_URL=$REACT_APP_FUEL_PROVIDER_URL npx ts-node deploy-contracts


### PR DESCRIPTION
This adds a way to deploy token and swayswap contracts, to other nodes by changing `.env` file. By default, it will try to deploy to `node.swayswap.io`.

ref.: #46 