### PR TITLE
fix: remove duplicated inputs

### DIFF
--- a/client/src/pages/Pool.tsx
+++ b/client/src/pages/Pool.tsx
@@ -88,6 +88,7 @@ export const Pool = () => {
         amount,
         transformRequest: async (request) => {
           // TODO: Remove after solving issues with duplicate inputs
+          // https://github.com/FuelLabs/fuels-ts/issues/229
           request.inputs = request.inputs.filter(i => {
             return !(i.type === InputType.Coin && i.assetId === coinFrom.assetId);
           });


### PR DESCRIPTION
I have implemented a temporary solution using `transformRequest`, fixing the balance increase during the creation of a pool.

Refs.: https://github.com/FuelLabs/fuels-ts/issues/229