### PR TITLE
Display Pool Reserves

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -31,7 +31,7 @@ jobs:
           CI: false
           PUBLIC_URL: "/${{ github.event.repository.name }}"
           REACT_APP_FUEL_PROVIDER_URL: "https://node.swayswap.io/graphql"
-          REACT_APP_CONTRACT_ID: "0x2447a39a1d383cccb3a00ab84841757801a42b846fb07d554f0e84b501c57963"
+          REACT_APP_CONTRACT_ID: "0xfd5cf5d4adca8036490a3d484bb103dee4fd5cde33ac05bbf8227aa9e21aed8d"
           REACT_APP_TOKEN_ID: "0x27d920c88f5c2a50ec248f546ea06a3ab0e238aa807fdfac4ee1c612e04657b3"
         run: |
           yarn install --frozen-lockfile

--- a/client/deploy-contracts/index.ts
+++ b/client/deploy-contracts/index.ts
@@ -4,7 +4,7 @@
 
 // TODO: Remove this file after `forc` enabled deploy a contract to a custom url
 // https://github.com/FuelLabs/sway/issues/1308
-import { hexlify, parseUnits, randomBytes } from 'ethers/lib/utils';
+import { parseUnits, randomBytes } from 'ethers/lib/utils';
 import {
   ContractFactory,
   NativeAssetId,

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -1,0 +1,8 @@
+import { parseUnits } from 'ethers/lib/utils';
+
+export const FUEL_PROVIDER_URL =
+  process.env.REACT_APP_FUEL_PROVIDER_URL || 'https://node.swayswap.io/graphql';
+export const CONTRACT_ID = process.env.REACT_APP_CONTRACT_ID!;
+export const TOKEN_ID = process.env.REACT_APP_TOKEN_ID!;
+export const FAUCET_AMOUNT = parseUnits('0.5', 9);
+export const MINT_AMOUNT = parseUnits('100', 9);

--- a/client/src/context/WalletContext.tsx
+++ b/client/src/context/WalletContext.tsx
@@ -7,9 +7,8 @@ import {
 } from "fuels";
 import { saveWallet, loadWallet } from "src/lib/walletStorage";
 import { CoinETH } from "src/lib/constants";
-import { parseUnits, randomBytes } from "ethers/lib/utils";
-
-const { REACT_APP_FUEL_PROVIDER_URL } = process.env;
+import { randomBytes } from "ethers/lib/utils";
+import { FAUCET_AMOUNT, FUEL_PROVIDER_URL } from "src/config";
 
 interface WalletProviderContext {
   sendTransaction: (data: any) => void;
@@ -30,7 +29,7 @@ export const WalletProvider = ({ children }: PropsWithChildren<{}>) => {
 
     if (!privateKey) return null;
 
-    return new Wallet(privateKey, REACT_APP_FUEL_PROVIDER_URL);
+    return new Wallet(privateKey, FUEL_PROVIDER_URL);
   };
 
   return (
@@ -38,7 +37,7 @@ export const WalletProvider = ({ children }: PropsWithChildren<{}>) => {
       value={{
         createWallet: () => {
           const wallet = Wallet.generate({
-            provider: REACT_APP_FUEL_PROVIDER_URL,
+            provider: FUEL_PROVIDER_URL,
           });
           saveWallet(wallet.privateKey);
           return wallet;
@@ -56,13 +55,13 @@ export const WalletProvider = ({ children }: PropsWithChildren<{}>) => {
           transactionRequest.addCoin({
             id: "0x000000000000000000000000000000000000000000000000000000000000000000",
             assetId: CoinETH,
-            amount: parseUnits(".5", 9),
+            amount: FAUCET_AMOUNT,
             owner:
               "0xf1e92c42b90934aa6372e30bc568a326f6e66a1a0288595e6e3fbd392a4f3e6e",
           });
           transactionRequest.addCoinOutput(
             wallet.address,
-            parseUnits(".5", 9),
+            FAUCET_AMOUNT,
             CoinETH
           );
           const submit = await wallet.sendTransaction(transactionRequest);

--- a/client/src/lib/CoinsMetadata.ts
+++ b/client/src/lib/CoinsMetadata.ts
@@ -1,4 +1,5 @@
 import { Coin } from 'src/components/CoinInput';
+import { CONTRACT_ID, TOKEN_ID } from 'src/config';
 
 const CoinsMetadata: Array<Coin> = [
   {
@@ -11,7 +12,7 @@ const CoinsMetadata: Array<Coin> = [
     // TODO: Remove this when adding dynamic token insertion
     // Make temporarily easy to change token contract id
     // https://github.com/FuelLabs/swayswap-demo/issues/33
-    assetId: process.env.REACT_APP_TOKEN_ID,
+    assetId: TOKEN_ID,
     img: '/icons/dai.svg',
   },
   {
@@ -19,7 +20,7 @@ const CoinsMetadata: Array<Coin> = [
     // TODO: Remove this when adding dynamic token insertion
     // Make temporarily easy to change token contract id
     // https://github.com/FuelLabs/swayswap-demo/issues/33
-    assetId: process.env.REACT_APP_CONTRACT_ID,
+    assetId: CONTRACT_ID,
     img: '/icons/sway.svg',
   },
 ];

--- a/client/src/pages/MintToken.tsx
+++ b/client/src/pages/MintToken.tsx
@@ -6,10 +6,9 @@ import { useWallet } from "src/context/WalletContext";
 import { TextInput } from "src/components/TextInput";
 import { useNavigate } from "react-router-dom";
 import { Pages } from "src/types/pages";
-import { parseUnits } from "ethers/lib/utils";
 import { objectId } from "src/lib/utils";
-
-const { REACT_APP_TOKEN_ID } = process.env;
+import { MINT_AMOUNT, TOKEN_ID } from "src/config";
+import { formatUnits } from "ethers/lib/utils";
 
 const style = {
   wrapper: `w-screen flex flex-1 items-center justify-center mb-14`,
@@ -21,14 +20,14 @@ const style = {
 
 export function MintToken() {
   const { getWallet } = useWallet();
-  const [asset, setAsset] = useState(REACT_APP_TOKEN_ID);
+  const [asset, setAsset] = useState(TOKEN_ID);
   const [isMinting, setMinting] = useState(true);
   const navigate = useNavigate();
 
   const handleMinCoins = async () => {
     const wallet = getWallet() as Wallet;
-    const token = TokenContractAbi__factory.connect(REACT_APP_TOKEN_ID, wallet);
-    const amount = parseUnits("1", 9);
+    const token = TokenContractAbi__factory.connect(TOKEN_ID, wallet);
+    const amount = MINT_AMOUNT;
 
     try {
       setMinting(true);
@@ -36,7 +35,7 @@ export function MintToken() {
       // Transfer the just minted coins to the output
       await token.functions.transfer_coins_to_output(
         amount,
-        objectId(REACT_APP_TOKEN_ID),
+        objectId(TOKEN_ID),
         objectId(wallet.address),
         {
           variableOutputs: 1,
@@ -74,7 +73,9 @@ export function MintToken() {
           onClick={(e) => isMinting && handleMinCoins()}
           className={style.confirmButton}
         >
-          {isMinting ? `Mint 1 token` : `Minting 1 token`}
+          {isMinting
+            ? `Mint ${formatUnits(MINT_AMOUNT, 9)} tokens`
+            : `Minting ${formatUnits(MINT_AMOUNT, 9)} tokens...`}
         </div>
       </div>
     </div>

--- a/client/src/pages/Pool.tsx
+++ b/client/src/pages/Pool.tsx
@@ -9,8 +9,7 @@ import { Coin, CoinInput } from "src/components/CoinInput";
 import { Spinner } from "src/components/Spinner";
 import { useNavigate } from "react-router-dom";
 import { Pages } from "src/types/pages";
-
-const { REACT_APP_CONTRACT_ID } = process.env;
+import { CONTRACT_ID } from "src/config";
 
 const style = {
   wrapper: `w-screen flex flex-1 items-center justify-center mb-14`,
@@ -77,10 +76,7 @@ export const Pool = () => {
     }
 
     const wallet = getWallet() as Wallet;
-    const contract = SwayswapContractAbi__factory.connect(
-      REACT_APP_CONTRACT_ID,
-      wallet
-    );
+    const contract = SwayswapContractAbi__factory.connect(CONTRACT_ID, wallet);
 
     // TODO: Combine all transactions on single tx leverage by scripts
     // https://github.com/FuelLabs/swayswap-demo/issues/42

--- a/client/src/pages/Pool.tsx
+++ b/client/src/pages/Pool.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import { BigNumber, InputType, Wallet } from "fuels";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { RiCheckFill } from "react-icons/ri";
 import { useWallet } from "src/context/WalletContext";
 import { SwayswapContractAbi__factory } from "src/types/contracts";
@@ -10,6 +10,7 @@ import { Spinner } from "src/components/Spinner";
 import { useNavigate } from "react-router-dom";
 import { Pages } from "src/types/pages";
 import { CONTRACT_ID } from "src/config";
+import { PoolInfoStruct } from "src/types/contracts/SwayswapContractAbi";
 
 const style = {
   wrapper: `w-screen flex flex-1 items-center justify-center mb-14`,
@@ -66,6 +67,18 @@ export const Pool = () => {
   const [toAmount, setToAmount] = useState(null as BigNumber | null);
   const [stage, setStage] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
+  const [poolInfo, setPoolInfo] = useState(null as PoolInfoStruct | null);
+
+  useEffect(() => {
+    const wallet = getWallet() as Wallet;
+    const contract = SwayswapContractAbi__factory.connect(CONTRACT_ID, wallet);
+
+    (async () => {
+      const pi = await contract.callStatic.get_info();
+      console.log(pi);
+      setPoolInfo(pi);
+    })();
+  }, [getWallet]);
 
   const provideLiquidity = async () => {
     if (!fromAmount) {
@@ -172,6 +185,20 @@ export const Pool = () => {
                 onChangeCoin={(coin: Coin) => setCoins([coinFrom, coin])}
               />
             </div>
+            {poolInfo ? (
+              <div
+                className="mt-3 ml-4 text-slate-400 decoration-1"
+                style={{
+                  fontFamily: "monospace",
+                }}
+              >
+                Reserves
+                <br />
+                ETH: {poolInfo.eth_reserve.toString()}
+                <br />
+                DAI: {poolInfo.token_reserve.toString()}
+              </div>
+            ) : null}
             <div
               onClick={(e) => provideLiquidity()}
               className={style.confirmButton}

--- a/client/src/pages/Pool.tsx
+++ b/client/src/pages/Pool.tsx
@@ -11,6 +11,7 @@ import { useNavigate } from "react-router-dom";
 import { Pages } from "src/types/pages";
 import { CONTRACT_ID } from "src/config";
 import { PoolInfoStruct } from "src/types/contracts/SwayswapContractAbi";
+import { formatUnits } from "ethers/lib/utils";
 
 const style = {
   wrapper: `w-screen flex flex-1 items-center justify-center mb-14`,
@@ -194,9 +195,21 @@ export const Pool = () => {
               >
                 Reserves
                 <br />
-                ETH: {poolInfo.eth_reserve.toString()}
+                ETH: {formatUnits(poolInfo.eth_reserve, 9).toString()}
                 <br />
-                DAI: {poolInfo.token_reserve.toString()}
+                DAI: {formatUnits(poolInfo.token_reserve, 9).toString()}
+                <br />
+                ETH/DAI:{" "}
+                {BigNumber.from(1000)
+                  .mul(poolInfo.eth_reserve)
+                  .div(poolInfo.token_reserve)
+                  .toNumber() / 1000}
+                <br />
+                DAI/ETH:{" "}
+                {BigNumber.from(1000)
+                  .mul(poolInfo.token_reserve)
+                  .div(poolInfo.eth_reserve)
+                  .toNumber() / 1000}
               </div>
             ) : null}
             <div

--- a/client/src/pages/RemoveLiquidity.tsx
+++ b/client/src/pages/RemoveLiquidity.tsx
@@ -7,8 +7,7 @@ import { CoinInput } from "src/components/CoinInput";
 import { useNavigate } from "react-router-dom";
 import { BigNumber, Wallet } from "fuels";
 import { Pages } from "src/types/pages";
-
-const { REACT_APP_CONTRACT_ID } = process.env;
+import { CONTRACT_ID } from "src/config";
 
 const style = {
   wrapper: `w-screen flex flex-1 items-center justify-center mb-14`,
@@ -20,9 +19,7 @@ const style = {
 };
 
 export const RemoveLiquidity = () => {
-  const liquidityToken = coins.find(
-    (c) => c.assetId === process.env.REACT_APP_CONTRACT_ID
-  );
+  const liquidityToken = coins.find((c) => c.assetId === CONTRACT_ID);
   const [amount, setAmount] = useState(null as BigNumber | null);
   const [balance, setBalance] = useState(null as BigNumber | null);
   const [isLoading, setLoading] = useState(false);
@@ -31,9 +28,7 @@ export const RemoveLiquidity = () => {
 
   const retrieveLiquidityToken = useCallback(async () => {
     const coins = await getCoins();
-    const liquidityToken = coins.find(
-      (c) => c.assetId === process.env.REACT_APP_CONTRACT_ID
-    );
+    const liquidityToken = coins.find((c) => c.assetId === CONTRACT_ID);
     return liquidityToken;
   }, [getCoins]);
 
@@ -49,17 +44,15 @@ export const RemoveLiquidity = () => {
     try {
       const wallet = getWallet() as Wallet;
       const swayswap = SwayswapContractAbi__factory.connect(
-        REACT_APP_CONTRACT_ID,
+        CONTRACT_ID,
         wallet
       );
       const amountValue = amount;
-      const coins = await wallet.getCoinsToSpend([
-        [amountValue, REACT_APP_CONTRACT_ID],
-      ]);
+      const coins = await wallet.getCoinsToSpend([[amountValue, CONTRACT_ID]]);
       // TODO: Add way to set min_eth and min_tokens
       // https://github.com/FuelLabs/swayswap/issues/55
       await swayswap.functions.remove_liquidity(1, 1, 1000, {
-        assetId: REACT_APP_CONTRACT_ID,
+        assetId: CONTRACT_ID,
         amount: amountValue,
         variableOutputs: 2,
         transformRequest: async (request) => {

--- a/client/src/types/contracts/SwayswapContractAbi.d.ts
+++ b/client/src/types/contracts/SwayswapContractAbi.d.ts
@@ -20,6 +20,11 @@ export type RemoveLiquidityReturnStruct = {
   token_amount: BigNumberish;
 };
 
+export type PoolInfoStruct = {
+  eth_reserve: BigNumberish;
+  token_reserve: BigNumberish;
+};
+
 interface SwayswapContractAbiInterface extends Interface {
   functions: {
     'deposit()': FunctionFragment;
@@ -28,6 +33,7 @@ interface SwayswapContractAbiInterface extends Interface {
     'remove_liquidity(u64,u64,u64)': FunctionFragment;
     'swap_with_minimum(u64,u64)': FunctionFragment;
     'swap_with_maximum(u64,u64)': FunctionFragment;
+    'get_info()': FunctionFragment;
   };
 
   encodeFunctionData(functionFragment: 'deposit', values?: undefined): string;
@@ -51,6 +57,7 @@ interface SwayswapContractAbiInterface extends Interface {
     functionFragment: 'swap_with_maximum',
     values: [BigNumberish, BigNumberish]
   ): string;
+  encodeFunctionData(functionFragment: 'get_info', values?: undefined): string;
 
   decodeFunctionData(functionFragment: 'deposit', data: BytesLike): DecodedValue;
   decodeFunctionData(functionFragment: 'withdraw', data: BytesLike): DecodedValue;
@@ -58,6 +65,7 @@ interface SwayswapContractAbiInterface extends Interface {
   decodeFunctionData(functionFragment: 'remove_liquidity', data: BytesLike): DecodedValue;
   decodeFunctionData(functionFragment: 'swap_with_minimum', data: BytesLike): DecodedValue;
   decodeFunctionData(functionFragment: 'swap_with_maximum', data: BytesLike): DecodedValue;
+  decodeFunctionData(functionFragment: 'get_info', data: BytesLike): DecodedValue;
 }
 
 export class SwayswapContractAbi extends Contract {
@@ -130,6 +138,12 @@ export class SwayswapContractAbi extends Contract {
       deadline: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<BigNumber>;
+
+    get_info(overrides?: Overrides & { from?: string | Promise<string> }): Promise<PoolInfoStruct>;
+
+    'get_info()'(
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<PoolInfoStruct>;
   };
 
   deposit(overrides?: Overrides & { from?: string | Promise<string> }): Promise<void>;
@@ -199,4 +213,10 @@ export class SwayswapContractAbi extends Contract {
     deadline: BigNumberish,
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<BigNumber>;
+
+  get_info(overrides?: Overrides & { from?: string | Promise<string> }): Promise<PoolInfoStruct>;
+
+  'get_info()'(
+    overrides?: Overrides & { from?: string | Promise<string> }
+  ): Promise<PoolInfoStruct>;
 }

--- a/client/src/types/contracts/factories/SwayswapContractAbi__factory.ts
+++ b/client/src/types/contracts/factories/SwayswapContractAbi__factory.ts
@@ -160,6 +160,29 @@ const _abi = [
       },
     ],
   },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'get_info',
+    outputs: [
+      {
+        name: '',
+        type: 'struct PoolInfo',
+        components: [
+          {
+            name: 'eth_reserve',
+            type: 'u64',
+            components: null,
+          },
+          {
+            name: 'token_reserve',
+            type: 'u64',
+            components: null,
+          },
+        ],
+      },
+    ],
+  },
 ];
 
 export class SwayswapContractAbi__factory {

--- a/contracts/swayswap_abi/src/main.sw
+++ b/contracts/swayswap_abi/src/main.sw
@@ -7,6 +7,11 @@ pub struct RemoveLiquidityReturn {
     token_amount: u64,
 }
 
+pub struct PoolInfo {
+    eth_reserve: u64,
+    token_reserve: u64,
+}
+
 abi Exchange {
     /// Deposit coins for later adding to liquidity pool.
     fn deposit();
@@ -20,4 +25,6 @@ abi Exchange {
     fn swap_with_minimum(min: u64, deadline: u64) -> u64;
     /// Swap ETH <-> Tokens and tranfers to sender.
     fn swap_with_maximum(amount: u64, deadline: u64) -> u64;
+    /// Get information on the liquidity pool.
+    fn get_info() -> PoolInfo;
 }

--- a/contracts/swayswap_contract/src/main.sw
+++ b/contracts/swayswap_contract/src/main.sw
@@ -2,7 +2,7 @@ contract;
 
 use std::{address::*, assert::assert, block::*, chain::auth::*, context::{*, call_frames::*}, contract_id::ContractId, hash::*, panic::panic, storage::*, token::*};
 use std::result::*;
-use swayswap_abi::{Exchange, RemoveLiquidityReturn};
+use swayswap_abi::{Exchange, RemoveLiquidityReturn, PoolInfo};
 
 ////////////////////////////////////////
 // Constants
@@ -254,5 +254,14 @@ impl Exchange for Contract {
         };
 
         sold
+    }
+
+    fn get_info() -> PoolInfo {
+        let eth_reserve = this_balance(~ContractId::from(ETH_ID));
+        let token_reserve = this_balance(~ContractId::from(TOKEN_ID));
+        PoolInfo {
+            eth_reserve: eth_reserve,
+            token_reserve: token_reserve,
+        }
     }
 }


### PR DESCRIPTION
[chore: add config.ts](https://github.com/FuelLabs/swayswap/commit/d8ee6e1cb659965fb0b33a723479b2dddde123bd)

Added a config file to easily change certain things. (Fauceting/minting 1 coin is never enough so I set those higher when developing, etc.)

[feat: display pool reserves](https://github.com/FuelLabs/swayswap/commit/5a8f64ee0c20716bb80a8d8ce37e7e7d9919bd89)

Adds a `get_info()` method to the SwaySwap contract that returns info about pool reserves and also displays the info on PoolPage.