### PR TITLE
ci: deploy page when a release is published

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,9 +1,8 @@
 name: GitHub Pages
 
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
- Change from release `swayswap` from `push to master` to `published a release`