### PR TITLE
fix: swap get values

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,7 +30,7 @@ jobs:
           CI: false
           PUBLIC_URL: "/${{ github.event.repository.name }}"
           REACT_APP_FUEL_PROVIDER_URL: "https://node.swayswap.io/graphql"
-          REACT_APP_CONTRACT_ID: "0x626f0c36909faecc316056fca8be684ab0cd06afc63247dc008bdf9e433f927a"
+          REACT_APP_CONTRACT_ID: "0x01a5dc6796bdf42909ffd2d7cd704952b461949ca61bff6ffe599cf662a90ecb"
           REACT_APP_TOKEN_ID: "0xb72c566e5a9f69c98298a04d70a38cb32baca4d9b280da8590e0314fb00c59e0"
         run: |
           yarn install --frozen-lockfile

--- a/client/deploy-contracts/index.ts
+++ b/client/deploy-contracts/index.ts
@@ -60,7 +60,7 @@ export async function deployContract(contextLog: string, binaryPath: string, abi
   const bytecode = fs.readFileSync(binaryPath);
   console.log(contextLog, 'Deploy contract...');
   const factory = new ContractFactory(bytecode, abi, wallet);
-  const contract = await factory.deployContract(ZeroBytes32);
+  const contract = await factory.deployContract([], ZeroBytes32);
 
   console.log(contextLog, 'Contract deployed...');
   return contract;

--- a/client/package.json
+++ b/client/package.json
@@ -65,6 +65,6 @@
     "prettier-plugin-tailwindcss": "^0.1.8",
     "tailwindcss": "^3.0.23",
     "typechain": "^8.0.0",
-    "typechain-target-fuels": "^0.0.0-master-f320686"
+    "typechain-target-fuels": "^0.0.0-master-5dea626c"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
     "@types/react-dom": "^18.0.3",
     "classnames": "^2.3.1",
     "ethers": "^5.5.4",
-    "fuels": "^0.0.0-master-0177b66",
+    "fuels": "^0.0.0-master-5dea626c",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-icons": "^4.3.1",

--- a/client/src/components/CoinInput.tsx
+++ b/client/src/components/CoinInput.tsx
@@ -6,6 +6,7 @@ import { useCallback } from "react";
 import { useEffect } from "react";
 import { Fragment, useState } from "react";
 import NumberFormat from "react-number-format";
+import { DECIMAL_UNITS } from "src/config";
 import urlJoin from "url-join";
 
 const { PUBLIC_URL } = process.env;
@@ -160,9 +161,11 @@ export function CoinInput({
       <div className="flex-1">
         <NumberFormat
           placeholder="0.0"
-          value={amount && formatUnits(amount, 9)}
+          value={amount && formatUnits(amount, DECIMAL_UNITS)}
           displayType={disabled ? "text" : "input"}
-          onValueChange={(e) => onChangeAmount?.(parseUnits(e.value, 9))}
+          onValueChange={(e) =>
+            onChangeAmount?.(parseUnits(e.value, DECIMAL_UNITS))
+          }
           className={style.transferPropInput}
           thousandSeparator={false}
           onInput={onInput}

--- a/client/src/components/CoinInput.tsx
+++ b/client/src/components/CoinInput.tsx
@@ -160,7 +160,8 @@ export function CoinInput({
     <div className={style.transferPropContainer}>
       <div className="flex-1">
         <NumberFormat
-          placeholder="0.0"
+          placeholder="0"
+          decimalScale={DECIMAL_UNITS}
           value={amount && formatUnits(amount, DECIMAL_UNITS)}
           displayType={disabled ? "text" : "input"}
           onValueChange={(e) =>

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -4,5 +4,7 @@ export const FUEL_PROVIDER_URL =
   process.env.REACT_APP_FUEL_PROVIDER_URL || 'https://node.swayswap.io/graphql';
 export const CONTRACT_ID = process.env.REACT_APP_CONTRACT_ID!;
 export const TOKEN_ID = process.env.REACT_APP_TOKEN_ID!;
-export const FAUCET_AMOUNT = parseUnits('0.5', 9);
-export const MINT_AMOUNT = parseUnits('0.5', 9);
+export const DECIMAL_UNITS = 9;
+export const FAUCET_AMOUNT = parseUnits('0.5', DECIMAL_UNITS);
+export const MINT_AMOUNT = parseUnits('0.5', DECIMAL_UNITS);
+export const ONE_ASSET = parseUnits('1', DECIMAL_UNITS).toNumber();

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -4,7 +4,7 @@ export const FUEL_PROVIDER_URL =
   process.env.REACT_APP_FUEL_PROVIDER_URL || 'https://node.swayswap.io/graphql';
 export const CONTRACT_ID = process.env.REACT_APP_CONTRACT_ID!;
 export const TOKEN_ID = process.env.REACT_APP_TOKEN_ID!;
-export const DECIMAL_UNITS = 9;
+export const DECIMAL_UNITS = 3;
 export const FAUCET_AMOUNT = parseUnits('0.5', DECIMAL_UNITS);
-export const MINT_AMOUNT = parseUnits('0.5', DECIMAL_UNITS);
+export const MINT_AMOUNT = parseUnits('2000', DECIMAL_UNITS);
 export const ONE_ASSET = parseUnits('1', DECIMAL_UNITS).toNumber();

--- a/client/src/pages/MintTokenPage.tsx
+++ b/client/src/pages/MintTokenPage.tsx
@@ -6,7 +6,7 @@ import { TextInput } from "src/components/TextInput";
 import { useNavigate } from "react-router-dom";
 import { Pages } from "src/types/pages";
 import { objectId } from "src/lib/utils";
-import { MINT_AMOUNT, TOKEN_ID } from "src/config";
+import { DECIMAL_UNITS, MINT_AMOUNT, TOKEN_ID } from "src/config";
 import { formatUnits } from "ethers/lib/utils";
 
 const style = {
@@ -72,8 +72,8 @@ export default function MintTokenPage() {
           className={style.confirmButton}
         >
           {isMinting
-            ? `Mint ${formatUnits(MINT_AMOUNT, 9)} tokens`
-            : `Minting ${formatUnits(MINT_AMOUNT, 9)} tokens...`}
+            ? `Mint ${formatUnits(MINT_AMOUNT, DECIMAL_UNITS)} tokens`
+            : `Minting ${formatUnits(MINT_AMOUNT, DECIMAL_UNITS)} tokens...`}
         </div>
       </div>
     </div>

--- a/client/src/pages/PoolPage.tsx
+++ b/client/src/pages/PoolPage.tsx
@@ -8,7 +8,7 @@ import { Coin, CoinInput } from "src/components/CoinInput";
 import { Spinner } from "src/components/Spinner";
 import { useNavigate } from "react-router-dom";
 import { Pages } from "src/types/pages";
-import { PoolInfoStruct } from "src/types/contracts/SwayswapContractAbi";
+import { PoolInfo } from "src/types/contracts/SwayswapContractAbi";
 import { formatUnits } from "ethers/lib/utils";
 import { DECIMAL_UNITS, ONE_ASSET } from "src/config";
 
@@ -67,7 +67,7 @@ export default function PoolPage() {
   const [toAmount, setToAmount] = useState(null as BigNumber | null);
   const [stage, setStage] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
-  const [poolInfo, setPoolInfo] = useState(null as PoolInfoStruct | null);
+  const [poolInfo, setPoolInfo] = useState(null as PoolInfo | null);
 
   useEffect(() => {
     (async () => {

--- a/client/src/pages/PoolPage.tsx
+++ b/client/src/pages/PoolPage.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from "react-router-dom";
 import { Pages } from "src/types/pages";
 import { PoolInfoStruct } from "src/types/contracts/SwayswapContractAbi";
 import { formatUnits } from "ethers/lib/utils";
+import { DECIMAL_UNITS, ONE_ASSET } from "src/config";
 
 const style = {
   wrapper: `w-screen flex flex-1 items-center justify-center mb-14`,
@@ -159,24 +160,26 @@ export default function PoolPage() {
               >
                 Reserves
                 <br />
-                ETH: {formatUnits(poolInfo.eth_reserve, 9).toString()}
+                ETH:{" "}
+                {formatUnits(poolInfo.eth_reserve, DECIMAL_UNITS).toString()}
                 <br />
-                DAI: {formatUnits(poolInfo.token_reserve, 9).toString()}
+                DAI:{" "}
+                {formatUnits(poolInfo.token_reserve, DECIMAL_UNITS).toString()}
                 {BigNumber.from(poolInfo.eth_reserve).gt(0) &&
                 BigNumber.from(poolInfo.token_reserve).gt(0) ? (
                   <>
                     <br />
                     ETH/DAI:{" "}
-                    {BigNumber.from(1000)
+                    {BigNumber.from(ONE_ASSET)
                       .mul(poolInfo.eth_reserve)
                       .div(poolInfo.token_reserve)
-                      .toNumber() / 1000}
+                      .toNumber() / ONE_ASSET}
                     <br />
                     DAI/ETH:{" "}
-                    {BigNumber.from(1000)
+                    {BigNumber.from(ONE_ASSET)
                       .mul(poolInfo.token_reserve)
                       .div(poolInfo.eth_reserve)
-                      .toNumber() / 1000}
+                      .toNumber() / ONE_ASSET}
                   </>
                 ) : null}
               </div>

--- a/client/src/pages/RemoveLiquidityPage.tsx
+++ b/client/src/pages/RemoveLiquidityPage.tsx
@@ -7,7 +7,7 @@ import { CoinInput } from "src/components/CoinInput";
 import { useNavigate } from "react-router-dom";
 import { BigNumber } from "fuels";
 import { Pages } from "src/types/pages";
-import { CONTRACT_ID } from "src/config";
+import { CONTRACT_ID, DECIMAL_UNITS } from "src/config";
 
 const style = {
   wrapper: `w-screen flex flex-1 items-center justify-center mb-14`,
@@ -87,7 +87,7 @@ export default function RemoveLiquidityPage() {
             className="mt-3 ml-4 cursor-pointer text-slate-400 underline decoration-1"
             onClick={() => setAmount(balance)}
           >
-            Max amount: {balance ? formatUnits(balance, 9) : "..."}
+            Max amount: {balance ? formatUnits(balance, DECIMAL_UNITS) : "..."}
           </div>
         </div>
         <button

--- a/client/src/types/contracts/SwayswapContractAbi.d.ts
+++ b/client/src/types/contracts/SwayswapContractAbi.d.ts
@@ -13,36 +13,42 @@ import type {
   BigNumber,
 } from 'fuels';
 
-export type ContractIdStruct = { value: string };
+export type ContractIdInput = { value: string };
 
-export type RemoveLiquidityReturnStruct = {
+export type ContractId = { value: string };
+
+export type RemoveLiquidityReturnInput = {
   eth_amount: BigNumberish;
   token_amount: BigNumberish;
 };
 
-export type PoolInfoStruct = {
+export type RemoveLiquidityReturn = {
+  eth_amount: BigNumber;
+  token_amount: BigNumber;
+};
+
+export type PoolInfoInput = {
   eth_reserve: BigNumberish;
   token_reserve: BigNumberish;
 };
 
+export type PoolInfo = { eth_reserve: BigNumber; token_reserve: BigNumber };
+
 interface SwayswapContractAbiInterface extends Interface {
   functions: {
-    'deposit()': FunctionFragment;
-    'withdraw(u64,struct ContractId)': FunctionFragment;
-    'add_liquidity(u64,u64,u64)': FunctionFragment;
-    'remove_liquidity(u64,u64,u64)': FunctionFragment;
-    'swap_with_minimum(u64,u64)': FunctionFragment;
-    'swap_with_maximum(u64,u64)': FunctionFragment;
-    'get_info()': FunctionFragment;
-    'swap_with_minimum_min_value(u64)': FunctionFragment;
-    'swap_with_maximum_forward_amount(u64)': FunctionFragment;
+    deposit: FunctionFragment;
+    withdraw: FunctionFragment;
+    add_liquidity: FunctionFragment;
+    remove_liquidity: FunctionFragment;
+    swap_with_minimum: FunctionFragment;
+    swap_with_maximum: FunctionFragment;
+    get_info: FunctionFragment;
+    get_swap_with_minimum: FunctionFragment;
+    get_swap_with_maximum: FunctionFragment;
   };
 
   encodeFunctionData(functionFragment: 'deposit', values?: undefined): string;
-  encodeFunctionData(
-    functionFragment: 'withdraw',
-    values: [BigNumberish, ContractIdStruct]
-  ): string;
+  encodeFunctionData(functionFragment: 'withdraw', values: [BigNumberish, ContractIdInput]): string;
   encodeFunctionData(
     functionFragment: 'add_liquidity',
     values: [BigNumberish, BigNumberish, BigNumberish]
@@ -60,14 +66,8 @@ interface SwayswapContractAbiInterface extends Interface {
     values: [BigNumberish, BigNumberish]
   ): string;
   encodeFunctionData(functionFragment: 'get_info', values?: undefined): string;
-  encodeFunctionData(
-    functionFragment: 'swap_with_minimum_min_value',
-    values: [BigNumberish]
-  ): string;
-  encodeFunctionData(
-    functionFragment: 'swap_with_maximum_forward_amount',
-    values: [BigNumberish]
-  ): string;
+  encodeFunctionData(functionFragment: 'get_swap_with_minimum', values?: undefined): string;
+  encodeFunctionData(functionFragment: 'get_swap_with_maximum', values?: undefined): string;
 
   decodeFunctionData(functionFragment: 'deposit', data: BytesLike): DecodedValue;
   decodeFunctionData(functionFragment: 'withdraw', data: BytesLike): DecodedValue;
@@ -76,14 +76,8 @@ interface SwayswapContractAbiInterface extends Interface {
   decodeFunctionData(functionFragment: 'swap_with_minimum', data: BytesLike): DecodedValue;
   decodeFunctionData(functionFragment: 'swap_with_maximum', data: BytesLike): DecodedValue;
   decodeFunctionData(functionFragment: 'get_info', data: BytesLike): DecodedValue;
-  decodeFunctionData(
-    functionFragment: 'swap_with_minimum_min_value',
-    data: BytesLike
-  ): DecodedValue;
-  decodeFunctionData(
-    functionFragment: 'swap_with_maximum_forward_amount',
-    data: BytesLike
-  ): DecodedValue;
+  decodeFunctionData(functionFragment: 'get_swap_with_minimum', data: BytesLike): DecodedValue;
+  decodeFunctionData(functionFragment: 'get_swap_with_maximum', data: BytesLike): DecodedValue;
 }
 
 export class SwayswapContractAbi extends Contract {
@@ -91,28 +85,13 @@ export class SwayswapContractAbi extends Contract {
   functions: {
     deposit(overrides?: Overrides & { from?: string | Promise<string> }): Promise<void>;
 
-    'deposit()'(overrides?: Overrides & { from?: string | Promise<string> }): Promise<void>;
-
     withdraw(
       amount: BigNumberish,
-      asset_id: ContractIdStruct,
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<void>;
-
-    'withdraw(u64,struct ContractId)'(
-      amount: BigNumberish,
-      asset_id: ContractIdStruct,
+      asset_id: ContractIdInput,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<void>;
 
     add_liquidity(
-      min_liquidity: BigNumberish,
-      max_tokens: BigNumberish,
-      deadline: BigNumberish,
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<BigNumber>;
-
-    'add_liquidity(u64,u64,u64)'(
       min_liquidity: BigNumberish,
       max_tokens: BigNumberish,
       deadline: BigNumberish,
@@ -124,22 +103,9 @@ export class SwayswapContractAbi extends Contract {
       min_tokens: BigNumberish,
       deadline: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<RemoveLiquidityReturnStruct>;
-
-    'remove_liquidity(u64,u64,u64)'(
-      min_eth: BigNumberish,
-      min_tokens: BigNumberish,
-      deadline: BigNumberish,
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<RemoveLiquidityReturnStruct>;
+    ): Promise<RemoveLiquidityReturn>;
 
     swap_with_minimum(
-      min: BigNumberish,
-      deadline: BigNumberish,
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<BigNumber>;
-
-    'swap_with_minimum(u64,u64)'(
       min: BigNumberish,
       deadline: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
@@ -151,63 +117,71 @@ export class SwayswapContractAbi extends Contract {
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<BigNumber>;
 
-    'swap_with_maximum(u64,u64)'(
+    get_info(overrides?: Overrides & { from?: string | Promise<string> }): Promise<PoolInfo>;
+
+    get_swap_with_minimum(
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<BigNumber>;
+
+    get_swap_with_maximum(
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<BigNumber>;
+  };
+  callStatic: {
+    deposit(overrides?: Overrides & { from?: string | Promise<string> }): Promise<void>;
+
+    withdraw(
+      amount: BigNumberish,
+      asset_id: ContractIdInput,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<void>;
+
+    add_liquidity(
+      min_liquidity: BigNumberish,
+      max_tokens: BigNumberish,
+      deadline: BigNumberish,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<BigNumber>;
+
+    remove_liquidity(
+      min_eth: BigNumberish,
+      min_tokens: BigNumberish,
+      deadline: BigNumberish,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<RemoveLiquidityReturn>;
+
+    swap_with_minimum(
+      min: BigNumberish,
+      deadline: BigNumberish,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<BigNumber>;
+
+    swap_with_maximum(
       amount: BigNumberish,
       deadline: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<BigNumber>;
 
-    get_info(overrides?: Overrides & { from?: string | Promise<string> }): Promise<PoolInfoStruct>;
+    get_info(overrides?: Overrides & { from?: string | Promise<string> }): Promise<PoolInfo>;
 
-    'get_info()'(
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<PoolInfoStruct>;
-
-    swap_with_minimum_min_value(
-      amount_to_forward: BigNumberish,
+    get_swap_with_minimum(
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<BigNumber>;
 
-    'swap_with_minimum_min_value(u64)'(
-      amount_to_forward: BigNumberish,
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<BigNumber>;
-
-    swap_with_maximum_forward_amount(
-      amount_to_receive: BigNumberish,
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<BigNumber>;
-
-    'swap_with_maximum_forward_amount(u64)'(
-      amount_to_receive: BigNumberish,
+    get_swap_with_maximum(
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<BigNumber>;
   };
 
   deposit(overrides?: Overrides & { from?: string | Promise<string> }): Promise<void>;
 
-  'deposit()'(overrides?: Overrides & { from?: string | Promise<string> }): Promise<void>;
-
   withdraw(
     amount: BigNumberish,
-    asset_id: ContractIdStruct,
-    overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<void>;
-
-  'withdraw(u64,struct ContractId)'(
-    amount: BigNumberish,
-    asset_id: ContractIdStruct,
+    asset_id: ContractIdInput,
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<void>;
 
   add_liquidity(
-    min_liquidity: BigNumberish,
-    max_tokens: BigNumberish,
-    deadline: BigNumberish,
-    overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<BigNumber>;
-
-  'add_liquidity(u64,u64,u64)'(
     min_liquidity: BigNumberish,
     max_tokens: BigNumberish,
     deadline: BigNumberish,
@@ -219,22 +193,9 @@ export class SwayswapContractAbi extends Contract {
     min_tokens: BigNumberish,
     deadline: BigNumberish,
     overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<RemoveLiquidityReturnStruct>;
-
-  'remove_liquidity(u64,u64,u64)'(
-    min_eth: BigNumberish,
-    min_tokens: BigNumberish,
-    deadline: BigNumberish,
-    overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<RemoveLiquidityReturnStruct>;
+  ): Promise<RemoveLiquidityReturn>;
 
   swap_with_minimum(
-    min: BigNumberish,
-    deadline: BigNumberish,
-    overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<BigNumber>;
-
-  'swap_with_minimum(u64,u64)'(
     min: BigNumberish,
     deadline: BigNumberish,
     overrides?: Overrides & { from?: string | Promise<string> }
@@ -246,35 +207,13 @@ export class SwayswapContractAbi extends Contract {
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<BigNumber>;
 
-  'swap_with_maximum(u64,u64)'(
-    amount: BigNumberish,
-    deadline: BigNumberish,
+  get_info(overrides?: Overrides & { from?: string | Promise<string> }): Promise<PoolInfo>;
+
+  get_swap_with_minimum(
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<BigNumber>;
 
-  get_info(overrides?: Overrides & { from?: string | Promise<string> }): Promise<PoolInfoStruct>;
-
-  'get_info()'(
-    overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<PoolInfoStruct>;
-
-  swap_with_minimum_min_value(
-    amount_to_forward: BigNumberish,
-    overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<BigNumber>;
-
-  'swap_with_minimum_min_value(u64)'(
-    amount_to_forward: BigNumberish,
-    overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<BigNumber>;
-
-  swap_with_maximum_forward_amount(
-    amount_to_receive: BigNumberish,
-    overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<BigNumber>;
-
-  'swap_with_maximum_forward_amount(u64)'(
-    amount_to_receive: BigNumberish,
+  get_swap_with_maximum(
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<BigNumber>;
 }

--- a/client/src/types/contracts/TokenContractAbi.d.ts
+++ b/client/src/types/contracts/TokenContractAbi.d.ts
@@ -13,32 +13,36 @@ import type {
   BigNumber,
 } from 'fuels';
 
-export type ContractIdStruct = { value: string };
+export type ContractIdInput = { value: string };
 
-export type AddressStruct = { value: string };
+export type ContractId = { value: string };
+
+export type AddressInput = { value: string };
+
+export type Address = { value: string };
 
 interface TokenContractAbiInterface extends Interface {
   functions: {
-    'mint_coins(u64)': FunctionFragment;
-    'burn_coins(u64)': FunctionFragment;
-    'force_transfer_coins(u64,struct ContractId,struct ContractId)': FunctionFragment;
-    'transfer_coins_to_output(u64,struct ContractId,struct Address)': FunctionFragment;
-    'get_balance(struct ContractId,struct ContractId)': FunctionFragment;
+    mint_coins: FunctionFragment;
+    burn_coins: FunctionFragment;
+    force_transfer_coins: FunctionFragment;
+    transfer_coins_to_output: FunctionFragment;
+    get_balance: FunctionFragment;
   };
 
   encodeFunctionData(functionFragment: 'mint_coins', values: [BigNumberish]): string;
   encodeFunctionData(functionFragment: 'burn_coins', values: [BigNumberish]): string;
   encodeFunctionData(
     functionFragment: 'force_transfer_coins',
-    values: [BigNumberish, ContractIdStruct, ContractIdStruct]
+    values: [BigNumberish, ContractIdInput, ContractIdInput]
   ): string;
   encodeFunctionData(
     functionFragment: 'transfer_coins_to_output',
-    values: [BigNumberish, ContractIdStruct, AddressStruct]
+    values: [BigNumberish, ContractIdInput, AddressInput]
   ): string;
   encodeFunctionData(
     functionFragment: 'get_balance',
-    values: [ContractIdStruct, ContractIdStruct]
+    values: [ContractIdInput, ContractIdInput]
   ): string;
 
   decodeFunctionData(functionFragment: 'mint_coins', data: BytesLike): DecodedValue;
@@ -56,7 +60,33 @@ export class TokenContractAbi extends Contract {
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<void>;
 
-    'mint_coins(u64)'(
+    burn_coins(
+      burn_amount: BigNumberish,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<void>;
+
+    force_transfer_coins(
+      coins: BigNumberish,
+      asset_id: ContractIdInput,
+      target: ContractIdInput,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<void>;
+
+    transfer_coins_to_output(
+      coins: BigNumberish,
+      asset_id: ContractIdInput,
+      recipient: AddressInput,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<void>;
+
+    get_balance(
+      target: ContractIdInput,
+      asset_id: ContractIdInput,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<BigNumber>;
+  };
+  callStatic: {
+    mint_coins(
       mint_amount: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<void>;
@@ -66,48 +96,23 @@ export class TokenContractAbi extends Contract {
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<void>;
 
-    'burn_coins(u64)'(
-      burn_amount: BigNumberish,
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<void>;
-
     force_transfer_coins(
       coins: BigNumberish,
-      asset_id: ContractIdStruct,
-      target: ContractIdStruct,
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<void>;
-
-    'force_transfer_coins(u64,struct ContractId,struct ContractId)'(
-      coins: BigNumberish,
-      asset_id: ContractIdStruct,
-      target: ContractIdStruct,
+      asset_id: ContractIdInput,
+      target: ContractIdInput,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<void>;
 
     transfer_coins_to_output(
       coins: BigNumberish,
-      asset_id: ContractIdStruct,
-      recipient: AddressStruct,
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<void>;
-
-    'transfer_coins_to_output(u64,struct ContractId,struct Address)'(
-      coins: BigNumberish,
-      asset_id: ContractIdStruct,
-      recipient: AddressStruct,
+      asset_id: ContractIdInput,
+      recipient: AddressInput,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<void>;
 
     get_balance(
-      target: ContractIdStruct,
-      asset_id: ContractIdStruct,
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<BigNumber>;
-
-    'get_balance(struct ContractId,struct ContractId)'(
-      target: ContractIdStruct,
-      asset_id: ContractIdStruct,
+      target: ContractIdInput,
+      asset_id: ContractIdInput,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<BigNumber>;
   };
@@ -117,58 +122,28 @@ export class TokenContractAbi extends Contract {
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<void>;
 
-  'mint_coins(u64)'(
-    mint_amount: BigNumberish,
-    overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<void>;
-
   burn_coins(
-    burn_amount: BigNumberish,
-    overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<void>;
-
-  'burn_coins(u64)'(
     burn_amount: BigNumberish,
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<void>;
 
   force_transfer_coins(
     coins: BigNumberish,
-    asset_id: ContractIdStruct,
-    target: ContractIdStruct,
-    overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<void>;
-
-  'force_transfer_coins(u64,struct ContractId,struct ContractId)'(
-    coins: BigNumberish,
-    asset_id: ContractIdStruct,
-    target: ContractIdStruct,
+    asset_id: ContractIdInput,
+    target: ContractIdInput,
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<void>;
 
   transfer_coins_to_output(
     coins: BigNumberish,
-    asset_id: ContractIdStruct,
-    recipient: AddressStruct,
-    overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<void>;
-
-  'transfer_coins_to_output(u64,struct ContractId,struct Address)'(
-    coins: BigNumberish,
-    asset_id: ContractIdStruct,
-    recipient: AddressStruct,
+    asset_id: ContractIdInput,
+    recipient: AddressInput,
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<void>;
 
   get_balance(
-    target: ContractIdStruct,
-    asset_id: ContractIdStruct,
-    overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<BigNumber>;
-
-  'get_balance(struct ContractId,struct ContractId)'(
-    target: ContractIdStruct,
-    asset_id: ContractIdStruct,
+    target: ContractIdInput,
+    asset_id: ContractIdInput,
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<BigNumber>;
 }

--- a/client/src/types/contracts/factories/SwayswapContractAbi__factory.ts
+++ b/client/src/types/contracts/factories/SwayswapContractAbi__factory.ts
@@ -185,14 +185,8 @@ const _abi = [
   },
   {
     type: 'function',
-    inputs: [
-      {
-        name: 'amount_to_forward',
-        type: 'u64',
-        components: null,
-      },
-    ],
-    name: 'swap_with_minimum_min_value',
+    inputs: [],
+    name: 'get_swap_with_minimum',
     outputs: [
       {
         name: '',
@@ -203,14 +197,8 @@ const _abi = [
   },
   {
     type: 'function',
-    inputs: [
-      {
-        name: 'amount_to_receive',
-        type: 'u64',
-        components: null,
-      },
-    ],
-    name: 'swap_with_maximum_forward_amount',
+    inputs: [],
+    name: 'get_swap_with_maximum',
     outputs: [
       {
         name: '',

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8847,6 +8847,11 @@ ts-essentials@^7.0.1:
   resolved "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz"
   integrity sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==
 
+ts-essentials@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-9.1.2.tgz#46db6944b73b4cd603f3d959ef1123c16ba56f59"
+  integrity sha512-EaSmXsAhEiirrTY1Oaa7TSpei9dzuCuFPmjKRJRPamERYtfaGS8/KpOSbjergLz/Y76/aZlV9i/krgzsuWEBbg==
+
 tsconfig-paths@^3.14.1:
   version "3.14.1"
   resolved "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz"
@@ -8921,12 +8926,14 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typechain-target-fuels@^0.0.0-master-f320686:
-  version "0.0.0-master-f320686"
-  resolved "https://registry.npmjs.org/typechain-target-fuels/-/typechain-target-fuels-0.0.0-master-f320686.tgz"
-  integrity sha512-ASEnifg/49tC9WmbUldWVjWSu8d/0BktD9Y3aA6YnBLtn0Gz7Tgu5FgtatUpS9ai4b/ENFAGW8iKaXf0WNpsRg==
+typechain-target-fuels@^0.0.0-master-5dea626c:
+  version "0.0.0-master-5dea626c"
+  resolved "https://registry.yarnpkg.com/typechain-target-fuels/-/typechain-target-fuels-0.0.0-master-5dea626c.tgz#290e1a0ecd39671d57ab7653d15a7af371e5406c"
+  integrity sha512-i0eMN/HGTzMQ3v3r30G7nEw+kQEyrfu/rOxc1092Oij5DSQQDKPsV813/INdEb+igO1FJDj6KsKjckbO1xUk2w==
   dependencies:
+    ts-essentials "^9.1.2"
     typechain "^6.0.2"
+    typescript "^4.5.2"
 
 typechain@^6.0.2:
   version "6.1.0"
@@ -8966,6 +8973,11 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
+
+typescript@^4.5.2:
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
+  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
 typescript@^4.5.5:
   version "4.6.3"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1511,10 +1511,10 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
-"@fuel-ts/abi-coder@0.0.0-master-0177b66":
-  version "0.0.0-master-0177b66"
-  resolved "https://registry.yarnpkg.com/@fuel-ts/abi-coder/-/abi-coder-0.0.0-master-0177b66.tgz#7712a86007a76df6ab4802900786d9db2b872534"
-  integrity sha512-VgSH+x5ldZTh4AMKqLZL9wHxTU26JaWkzL5QssC4bDk8nEfz/7s2hg9xn/HbBMQsZCGmxQUNsQ8Qupk4vumGSg==
+"@fuel-ts/abi-coder@0.0.0-master-5dea626c":
+  version "0.0.0-master-5dea626c"
+  resolved "https://registry.yarnpkg.com/@fuel-ts/abi-coder/-/abi-coder-0.0.0-master-5dea626c.tgz#2697a014637aa10cccdb36d9f642d49bbdfbd487"
+  integrity sha512-57xAUNJalL7MzrOc1yhyyUncUoSoOWfw/McuVNhmK2p3i4acHiQCMcNXUIa3kUhb6X0SShWcMP18NfEyiDKY9A==
   dependencies:
     "@ethersproject/abi" "^5.4.1"
     "@ethersproject/bignumber" "^5.4.2"
@@ -1523,144 +1523,144 @@
     "@ethersproject/sha2" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
 
-"@fuel-ts/constants@0.0.0-master-0177b66":
-  version "0.0.0-master-0177b66"
-  resolved "https://registry.yarnpkg.com/@fuel-ts/constants/-/constants-0.0.0-master-0177b66.tgz#6426debccd7504b85c475b28687bd266d962725a"
-  integrity sha512-lC0IjDGGv8ZSNsOQ6ETSknm8d34vrwkfxEB7LHFa31/JJKHvhjSdYfSEZ00UC9aS9vMr5/JsTwjFdLrPEGnRDw==
+"@fuel-ts/constants@0.0.0-master-5dea626c":
+  version "0.0.0-master-5dea626c"
+  resolved "https://registry.yarnpkg.com/@fuel-ts/constants/-/constants-0.0.0-master-5dea626c.tgz#289ff016b3e3c42edd9b0683733ec12873ac882c"
+  integrity sha512-RJduKlRKJMgaFcVKGwe1yOEKy09A2NFQ36meZguWQUH0IUFBTXdknW9rK+JFNegmc7YdDaqLpXXPde6Si6KmCw==
 
-"@fuel-ts/contract@0.0.0-master-0177b66":
-  version "0.0.0-master-0177b66"
-  resolved "https://registry.yarnpkg.com/@fuel-ts/contract/-/contract-0.0.0-master-0177b66.tgz#a7fe86adcfbbcaa32bf0e338ed7091ca25ae726b"
-  integrity sha512-HjOSpKGNzfS/04Ud2Ild2R3ZergJtFdKCQrG3yB/MQxq+ELguhSEEwlio+xdNTXHzdtKtH1gWU5tAcNxdKbtTg==
+"@fuel-ts/contract@0.0.0-master-5dea626c":
+  version "0.0.0-master-5dea626c"
+  resolved "https://registry.yarnpkg.com/@fuel-ts/contract/-/contract-0.0.0-master-5dea626c.tgz#9fa25fa07b190d1d0b630ffd912bd008faefccdb"
+  integrity sha512-C0YrbHx6v+CZn5Yr0jre+amAUpvhrDGFjoumlKbEjZuDnFtxadSCi2IvOZIHu6w1Ek8flDeqKmcc1QbH+KMiNg==
   dependencies:
     "@ethersproject/bignumber" "^5.5.0"
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/random" "^5.5.1"
     "@ethersproject/sha2" "^5.6.0"
-    "@fuel-ts/abi-coder" "0.0.0-master-0177b66"
-    "@fuel-ts/constants" "0.0.0-master-0177b66"
-    "@fuel-ts/interfaces" "0.0.0-master-0177b66"
-    "@fuel-ts/merkle" "0.0.0-master-0177b66"
-    "@fuel-ts/providers" "0.0.0-master-0177b66"
-    "@fuel-ts/wallet" "0.0.0-master-0177b66"
+    "@fuel-ts/abi-coder" "0.0.0-master-5dea626c"
+    "@fuel-ts/constants" "0.0.0-master-5dea626c"
+    "@fuel-ts/interfaces" "0.0.0-master-5dea626c"
+    "@fuel-ts/merkle" "0.0.0-master-5dea626c"
+    "@fuel-ts/providers" "0.0.0-master-5dea626c"
+    "@fuel-ts/wallet" "0.0.0-master-5dea626c"
 
-"@fuel-ts/hasher@0.0.0-master-0177b66":
-  version "0.0.0-master-0177b66"
-  resolved "https://registry.yarnpkg.com/@fuel-ts/hasher/-/hasher-0.0.0-master-0177b66.tgz#e9e058b571e7de22faabc4ab0954a41edbe46853"
-  integrity sha512-b6yeHA6/D1EFsHWmXJ5vD2mzUhAkuShrdvpcbEganj7B0U1y2PYCYFx8OjSbrI6Wy3YA/wm8JvzLGVTNSFap3A==
+"@fuel-ts/hasher@0.0.0-master-5dea626c":
+  version "0.0.0-master-5dea626c"
+  resolved "https://registry.yarnpkg.com/@fuel-ts/hasher/-/hasher-0.0.0-master-5dea626c.tgz#95124cb3b072099a6396dc0235cb0ef4cc33345c"
+  integrity sha512-ecdT1YF5w76DL+3hGr/aVU+J9OOCCKgNpwajiBPke0GEJfo2Ni+jXRpD6wyKRuZ2InvwZ75PWdoQhW+KzgZGhg==
   dependencies:
     "@ethersproject/bignumber" "^5.5.0"
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/sha2" "^5.5.0"
-    "@fuel-ts/constants" "0.0.0-master-0177b66"
-    "@fuel-ts/providers" "0.0.0-master-0177b66"
+    "@fuel-ts/constants" "0.0.0-master-5dea626c"
+    "@fuel-ts/providers" "0.0.0-master-5dea626c"
     lodash.clonedeep "^4.5.0"
 
-"@fuel-ts/hdwallet@0.0.0-master-0177b66":
-  version "0.0.0-master-0177b66"
-  resolved "https://registry.yarnpkg.com/@fuel-ts/hdwallet/-/hdwallet-0.0.0-master-0177b66.tgz#68545af69cc2ddfd054d07adb80b9d322d318af5"
-  integrity sha512-NSdibpW/cK7d0zBap8aEV12l08ZcV6UPzAZgzvrGRAWL9Dg4gofL0PBZsIg0rfq4puQSzwlsuOuTbkCHddqQjQ==
+"@fuel-ts/hdwallet@0.0.0-master-5dea626c":
+  version "0.0.0-master-5dea626c"
+  resolved "https://registry.yarnpkg.com/@fuel-ts/hdwallet/-/hdwallet-0.0.0-master-5dea626c.tgz#23df4d6daf0fe0b89b6e97ba1005f1626e25d529"
+  integrity sha512-FQpkGg+hLWxULnbUErrbvm5a924IEYO6VEpIlA9eS04ord3ckqzd0QY0Id3AOyySgmusEtC18oPEF88aiJn1mQ==
   dependencies:
     "@ethersproject/basex" "^5.5.0"
     "@ethersproject/bignumber" "^5.5.0"
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/sha2" "^5.5.0"
-    "@fuel-ts/mnemonic" "0.0.0-master-0177b66"
-    "@fuel-ts/signer" "0.0.0-master-0177b66"
+    "@fuel-ts/mnemonic" "0.0.0-master-5dea626c"
+    "@fuel-ts/signer" "0.0.0-master-5dea626c"
 
-"@fuel-ts/interfaces@0.0.0-master-0177b66":
-  version "0.0.0-master-0177b66"
-  resolved "https://registry.yarnpkg.com/@fuel-ts/interfaces/-/interfaces-0.0.0-master-0177b66.tgz#ad892eb7ab4e07189bfa538fc8da98addbce936b"
-  integrity sha512-43cCVx7IyYTtS7l0LJIkcywAhI55bQQhSxPD7/iX6LNXpWOh9YY3fTXXhHpuTKGdzf9Tr8B2IOFcxw04QvV/Fw==
+"@fuel-ts/interfaces@0.0.0-master-5dea626c":
+  version "0.0.0-master-5dea626c"
+  resolved "https://registry.yarnpkg.com/@fuel-ts/interfaces/-/interfaces-0.0.0-master-5dea626c.tgz#3b02cd9577c2003bf15aac91eafb4aa20c174638"
+  integrity sha512-zu5rsc4EkgxMn8l4V/FMBfTdS/wbGdH0cxlGV1E85xH3vj66ym6beZgnpcHD5JHsyy+it73VWoYOpdY9XpXNHA==
   dependencies:
     "@ethersproject/bignumber" "^5.6.0"
     "@ethersproject/bytes" "^5.6.0"
 
-"@fuel-ts/merkle-shared@0.0.0-master-0177b66":
-  version "0.0.0-master-0177b66"
-  resolved "https://registry.yarnpkg.com/@fuel-ts/merkle-shared/-/merkle-shared-0.0.0-master-0177b66.tgz#18427cba838794f84b16e14e19e167485c5591c5"
-  integrity sha512-ew+ZjMUF7Abr0/j01bsy/KhpLLjeFKsk9Aj3dL0eagOsT49x/DR85S5kwQVV9kpV2HC5M6oO1fE1BlK4i/TKYA==
+"@fuel-ts/merkle-shared@0.0.0-master-5dea626c":
+  version "0.0.0-master-5dea626c"
+  resolved "https://registry.yarnpkg.com/@fuel-ts/merkle-shared/-/merkle-shared-0.0.0-master-5dea626c.tgz#98773346c585f85405aea58c8b0516b18b971781"
+  integrity sha512-Y3zpVcM1oLkSndA3MSoMT9XXvpOOYeZHBpH/ma+R+q0vvYVudFsMqZL6cnlQtKCB9DMxpwbM1FCBnGnrns6uAA==
   dependencies:
     "@ethersproject/bignumber" "^5.4.2"
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/sha2" "^5.4.0"
 
-"@fuel-ts/merkle@0.0.0-master-0177b66":
-  version "0.0.0-master-0177b66"
-  resolved "https://registry.yarnpkg.com/@fuel-ts/merkle/-/merkle-0.0.0-master-0177b66.tgz#afe8e97adf60c84f59e70c1a7b2c16f8fbdbd3a2"
-  integrity sha512-egl1siiK3tNj+oJNVNBimbW1uXDlJKl53WV9fzhqaBVTPk6PiZCub6wMtxkBgLJatBFdFTkK7zP0SSaYBs4jPw==
+"@fuel-ts/merkle@0.0.0-master-5dea626c":
+  version "0.0.0-master-5dea626c"
+  resolved "https://registry.yarnpkg.com/@fuel-ts/merkle/-/merkle-0.0.0-master-5dea626c.tgz#d7371c3a3c599f302d18a24e05e7040a4ac4d9ea"
+  integrity sha512-Klx3dVSGgOohkzmA4oTCzZVTQP8nX3Bu4IZ//9NpP5W3n+rh11BiXT2uTdlLNgzOnQNFNpoU5KZgV0f72ejnpQ==
   dependencies:
-    "@fuel-ts/merkle-shared" "0.0.0-master-0177b66"
+    "@fuel-ts/merkle-shared" "0.0.0-master-5dea626c"
 
-"@fuel-ts/mnemonic@0.0.0-master-0177b66":
-  version "0.0.0-master-0177b66"
-  resolved "https://registry.yarnpkg.com/@fuel-ts/mnemonic/-/mnemonic-0.0.0-master-0177b66.tgz#729f6475bb2f67102b00497d5a31ac44ebf1b611"
-  integrity sha512-QubrAUOmdvtOPIUf62e+Qz/xokKIcSgKX3Nd/IYph1PwrB/rrXA98BBEqVeNXXl0S+jO9QOXyXbZEp6qZ+05AQ==
+"@fuel-ts/mnemonic@0.0.0-master-5dea626c":
+  version "0.0.0-master-5dea626c"
+  resolved "https://registry.yarnpkg.com/@fuel-ts/mnemonic/-/mnemonic-0.0.0-master-5dea626c.tgz#0972028c297f0dbcf6cc11f1afd0266f67bebb88"
+  integrity sha512-XASFK8dk5gK1Z8TeHW+FArUJLH4aas4fT1ysDnym4TS3z/E1EjlXxJiNxlCCNT1l6hq+GFDfbHwKBfby6I4Fug==
   dependencies:
     "@ethersproject/basex" "^5.5.0"
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/pbkdf2" "^5.5.0"
     "@ethersproject/random" "^5.5.1"
     "@ethersproject/sha2" "^5.5.0"
-    "@fuel-ts/wordlists" "0.0.0-master-0177b66"
+    "@fuel-ts/wordlists" "0.0.0-master-5dea626c"
 
-"@fuel-ts/providers@0.0.0-master-0177b66":
-  version "0.0.0-master-0177b66"
-  resolved "https://registry.yarnpkg.com/@fuel-ts/providers/-/providers-0.0.0-master-0177b66.tgz#fd919584802908c0aa63307592e3d37a13b045ee"
-  integrity sha512-HsTXHU+5AjqzhKns3Qo4vX74hX4ffPosq4C2BGQaJ9qvzqcucD4Rzoo778hvj9esU7vEErME51H8QmJ3TdKNeQ==
+"@fuel-ts/providers@0.0.0-master-5dea626c":
+  version "0.0.0-master-5dea626c"
+  resolved "https://registry.yarnpkg.com/@fuel-ts/providers/-/providers-0.0.0-master-5dea626c.tgz#573537a39b0b63e935deed4b0345f82df30e8fd8"
+  integrity sha512-L9Uj8OMtqiNy779Ib9qiyiFwmZ+JtpNfsguicFpiyUenU20vWUdCCcInJ2vD9xQ/dhMCBqEnY58xGOSqUJSN4g==
   dependencies:
     "@ethersproject/bignumber" "^5.4.2"
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/networks" "^5.5.0"
     "@ethersproject/random" "^5.5.1"
     "@ethersproject/sha2" "^5.5.0"
-    "@fuel-ts/constants" "0.0.0-master-0177b66"
-    "@fuel-ts/interfaces" "0.0.0-master-0177b66"
-    "@fuel-ts/transactions" "0.0.0-master-0177b66"
+    "@fuel-ts/constants" "0.0.0-master-5dea626c"
+    "@fuel-ts/interfaces" "0.0.0-master-5dea626c"
+    "@fuel-ts/transactions" "0.0.0-master-5dea626c"
     graphql "^15.6.1"
     graphql-request "^3.6.1"
     graphql-tag "^2.12.6"
 
-"@fuel-ts/signer@0.0.0-master-0177b66":
-  version "0.0.0-master-0177b66"
-  resolved "https://registry.yarnpkg.com/@fuel-ts/signer/-/signer-0.0.0-master-0177b66.tgz#e3800b77d45f75829f31d3054d3482e4feca9e37"
-  integrity sha512-zPPxMqfX/SUYFUFPExeNTad6CDclxRfg1CosHNuev0CkI+fvcoTtQEKyC01EfaHwCn1TfaYMxyr2AJFLjUw8Og==
+"@fuel-ts/signer@0.0.0-master-5dea626c":
+  version "0.0.0-master-5dea626c"
+  resolved "https://registry.yarnpkg.com/@fuel-ts/signer/-/signer-0.0.0-master-5dea626c.tgz#9f55f3a721a5944926cea81be8e4cc27fb1961e3"
+  integrity sha512-UvVJ2LI0GJaZCjUGSv4yOxVvNNsTWeo9cjXZvnthfjftsRLnWeBT4wLFmZoSslUougl6mez4lRWdSkEpzwehIg==
   dependencies:
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/random" "5.5.1"
     "@ethersproject/sha2" "^5.5.0"
-    "@fuel-ts/hasher" "0.0.0-master-0177b66"
+    "@fuel-ts/hasher" "0.0.0-master-5dea626c"
     elliptic "^6.5.4"
 
-"@fuel-ts/transactions@0.0.0-master-0177b66":
-  version "0.0.0-master-0177b66"
-  resolved "https://registry.yarnpkg.com/@fuel-ts/transactions/-/transactions-0.0.0-master-0177b66.tgz#3e093fbe0d11de02beccf0e1b3aedd84d7dbef12"
-  integrity sha512-WAZDzMiyb7YTxhaJhfMdkXh6zcWWjN6rJoveTSotl5i7fhAgcQU5zhBgLQaN6O0ACSZAbSR0ZWvj95UugwEpGw==
+"@fuel-ts/transactions@0.0.0-master-5dea626c":
+  version "0.0.0-master-5dea626c"
+  resolved "https://registry.yarnpkg.com/@fuel-ts/transactions/-/transactions-0.0.0-master-5dea626c.tgz#ad5f3a81cc198406f5a3b0f42b8ccd64c321a0a6"
+  integrity sha512-CLtMn0LQJIIMHPYI5+qcEE0or+/mR50i5QNl9Z1pjm4w19kPZ3lYTmp4+TC+oG6E1swW7JU/RRdUxId3Z1QXTw==
   dependencies:
     "@ethersproject/bignumber" "^5.4.2"
     "@ethersproject/bytes" "^5.4.0"
-    "@fuel-ts/abi-coder" "0.0.0-master-0177b66"
-    "@fuel-ts/constants" "0.0.0-master-0177b66"
+    "@fuel-ts/abi-coder" "0.0.0-master-5dea626c"
+    "@fuel-ts/constants" "0.0.0-master-5dea626c"
 
-"@fuel-ts/wallet@0.0.0-master-0177b66":
-  version "0.0.0-master-0177b66"
-  resolved "https://registry.yarnpkg.com/@fuel-ts/wallet/-/wallet-0.0.0-master-0177b66.tgz#4f702c7da23695f286ebf187ecd52cb0eb1a3581"
-  integrity sha512-Lze4U+d04Zo+XIonKLe4PeYzZRpyP0mpMXBQ7r6mxLlDEjPGXSrZw9jxPfE8Os+pab77NuvfnL1RW+9bjkRFng==
+"@fuel-ts/wallet@0.0.0-master-5dea626c":
+  version "0.0.0-master-5dea626c"
+  resolved "https://registry.yarnpkg.com/@fuel-ts/wallet/-/wallet-0.0.0-master-5dea626c.tgz#333fc69ef1e2caab0b90a07bd95968f9c9520d2d"
+  integrity sha512-f1ymbENcfocqJUQqT7PFa73bROPss9XsrTBLpSMWlWUOqy2Bdh8517gJs2RpkBVvEC7l9FFdq7rp1BbCiFa53Q==
   dependencies:
     "@ethersproject/bytes" "^5.5.0"
-    "@fuel-ts/constants" "0.0.0-master-0177b66"
-    "@fuel-ts/hasher" "0.0.0-master-0177b66"
-    "@fuel-ts/hdwallet" "0.0.0-master-0177b66"
-    "@fuel-ts/interfaces" "0.0.0-master-0177b66"
-    "@fuel-ts/mnemonic" "0.0.0-master-0177b66"
-    "@fuel-ts/providers" "0.0.0-master-0177b66"
-    "@fuel-ts/signer" "0.0.0-master-0177b66"
+    "@fuel-ts/constants" "0.0.0-master-5dea626c"
+    "@fuel-ts/hasher" "0.0.0-master-5dea626c"
+    "@fuel-ts/hdwallet" "0.0.0-master-5dea626c"
+    "@fuel-ts/interfaces" "0.0.0-master-5dea626c"
+    "@fuel-ts/mnemonic" "0.0.0-master-5dea626c"
+    "@fuel-ts/providers" "0.0.0-master-5dea626c"
+    "@fuel-ts/signer" "0.0.0-master-5dea626c"
 
-"@fuel-ts/wordlists@0.0.0-master-0177b66":
-  version "0.0.0-master-0177b66"
-  resolved "https://registry.yarnpkg.com/@fuel-ts/wordlists/-/wordlists-0.0.0-master-0177b66.tgz#53aaea8fa10081af5a85e9a4e86f3bacf510bfb3"
-  integrity sha512-M9b2zM3u4wGT2hDpI0fT+9NOJb1o/ZZ5tLgUukb2/5BleibjpSp4ZTTw9j2v7Vjado/zU/ZEmv5F1Y6dK5So5A==
+"@fuel-ts/wordlists@0.0.0-master-5dea626c":
+  version "0.0.0-master-5dea626c"
+  resolved "https://registry.yarnpkg.com/@fuel-ts/wordlists/-/wordlists-0.0.0-master-5dea626c.tgz#8064a5d5c83c0a7d7ac335790c0020cdd94c13b6"
+  integrity sha512-/G/0SvjMXczijXDW/G1CGfY9D+gu+TZlt7bJjMieB62E2L78gfl5PmAUGfVVm7LN7oW4S/WrL2YwZywSr0CPNw==
 
 "@headlessui/react@^1.5.0":
   version "1.5.0"
@@ -4940,19 +4940,19 @@ fsevents@^2.3.2, fsevents@~2.3.2:
   resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
-fuels@^0.0.0-master-0177b66:
-  version "0.0.0-master-0177b66"
-  resolved "https://registry.yarnpkg.com/fuels/-/fuels-0.0.0-master-0177b66.tgz#950f919069cb1c927eee7a4b5bea412b097c1da4"
-  integrity sha512-xU3m81e8UZkhvskdXCcQj2+3CqgtxbnI6SMLy8Y4esFEMuDW2UjMPh1Nwsq2k5ODeFM6KbyUhGHfQwNw/tVnKg==
+fuels@^0.0.0-master-5dea626c:
+  version "0.0.0-master-5dea626c"
+  resolved "https://registry.yarnpkg.com/fuels/-/fuels-0.0.0-master-5dea626c.tgz#b2dfa0a175748469e5744a7b993ad1a51c73b05d"
+  integrity sha512-nuY/WJMiOl7Xz8Yc2h+d0bjHln5RZezb51MoAYAPPmeyB/JF1pSN6wTgtT3NuBrpbrSLWXNxyGNTw3srkCUd+Q==
   dependencies:
     "@ethersproject/bignumber" "^5.6.0"
     "@ethersproject/bytes" "^5.6.0"
-    "@fuel-ts/abi-coder" "0.0.0-master-0177b66"
-    "@fuel-ts/constants" "0.0.0-master-0177b66"
-    "@fuel-ts/contract" "0.0.0-master-0177b66"
-    "@fuel-ts/providers" "0.0.0-master-0177b66"
-    "@fuel-ts/transactions" "0.0.0-master-0177b66"
-    "@fuel-ts/wallet" "0.0.0-master-0177b66"
+    "@fuel-ts/abi-coder" "0.0.0-master-5dea626c"
+    "@fuel-ts/constants" "0.0.0-master-5dea626c"
+    "@fuel-ts/contract" "0.0.0-master-5dea626c"
+    "@fuel-ts/providers" "0.0.0-master-5dea626c"
+    "@fuel-ts/transactions" "0.0.0-master-5dea626c"
+    "@fuel-ts/wallet" "0.0.0-master-5dea626c"
 
 function-bind@^1.1.1:
   version "1.1.1"

--- a/contracts/swayswap_abi/src/main.sw
+++ b/contracts/swayswap_abi/src/main.sw
@@ -28,7 +28,7 @@ abi Exchange {
     /// Get information on the liquidity pool.
     fn get_info() -> PoolInfo;
     /// Get the minimum amount of coins that will be received for a swap_with_minimum.
-    fn swap_with_minimum_min_value(amount_to_forward: u64) -> u64;
+    fn get_swap_with_minimum() -> u64;
     /// Get required amount of coins for a swap_with_maximum.
-    fn swap_with_maximum_forward_amount(amount_to_receive: u64) -> u64;
+    fn get_swap_with_maximum() -> u64;
 }

--- a/contracts/swayswap_contract/Forc.lock
+++ b/contracts/swayswap_contract/Forc.lock
@@ -4,16 +4,16 @@ dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.11.0#95816e4e41aae1d3425ba6ff5e7266076d8400fa'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.12.1#a03a5d1c068a91779e5ce08eead6c4626de2eb0d'
 dependencies = ['core']
 
 [[package]]
 name = 'swayswap_abi'
-dependencies = ['std git+https://github.com/fuellabs/sway?tag=v0.11.0#95816e4e41aae1d3425ba6ff5e7266076d8400fa']
+dependencies = ['std git+https://github.com/fuellabs/sway?tag=v0.12.1#a03a5d1c068a91779e5ce08eead6c4626de2eb0d']
 
 [[package]]
 name = 'swayswap_contract'
 dependencies = [
-    'std git+https://github.com/fuellabs/sway?tag=v0.11.0#95816e4e41aae1d3425ba6ff5e7266076d8400fa',
+    'std git+https://github.com/fuellabs/sway?tag=v0.12.1#a03a5d1c068a91779e5ce08eead6c4626de2eb0d',
     'swayswap_abi',
 ]

--- a/contracts/swayswap_contract/src/main.sw
+++ b/contracts/swayswap_contract/src/main.sw
@@ -139,8 +139,8 @@ impl Exchange for Contract {
             assert(min_liquidity > 0);
 
             let eth_reserve = get_current_balance(ETH_ID) - eth_amount;
-            let token_reserve = get_current_balance(TOKEN_ID);
-            let token_amount = (eth_amount * token_reserve) / eth_reserve + 1;
+            let token_reserve = get_current_balance(TOKEN_ID) - current_token_amount;
+            let token_amount = (eth_amount * token_reserve) / eth_reserve;
             let liquidity_minted = (eth_amount * total_liquidity) / eth_reserve;
 
             assert(max_tokens >= token_amount);
@@ -152,7 +152,7 @@ impl Exchange for Contract {
 
             transfer_to_output(liquidity_minted, contract_id(), sender);
 
-            store(token_amount_key, current_token_amount - token_amount);
+            store(token_amount_key, token_amount - current_token_amount);
 
             minted = liquidity_minted;
         } else {

--- a/contracts/swayswap_contract/src/main.sw
+++ b/contracts/swayswap_contract/src/main.sw
@@ -44,20 +44,26 @@ fn get_current_balance(token_id: b256) -> u64 {
     this_balance(~ContractId::from(token_id))
 }
 
+// Calculate 0.3% fee
+fn calculate_amount_with_fee(amount: u64) -> u64 {
+    let fee: u64 = (amount / 333);
+    amount - fee
+}
+
 /// Pricing function for converting between ETH and Tokens.
 fn get_input_price(input_amount: u64, input_reserve: u64, output_reserve: u64) -> u64 {
     assert(input_reserve > 0 && output_reserve > 0);
-    let input_amount_with_fee: u64 = input_amount * 997;
+    let input_amount_with_fee: u64 = calculate_amount_with_fee(input_amount);
     let numerator: u64 = input_amount_with_fee * output_reserve;
-    let denominator: u64 = (input_reserve * 1000) + input_amount_with_fee;
+    let denominator: u64 = input_reserve + input_amount_with_fee;
     numerator / denominator
 }
 
 /// Pricing function for converting between ETH and Tokens.
 fn get_output_price(output_amount: u64, input_reserve: u64, output_reserve: u64) -> u64 {
     assert(input_reserve > 0 && output_reserve > 0);
-    let numerator: u64 = input_reserve * output_amount * 1000;
-    let denominator: u64 = (output_reserve - output_amount) * 997;
+    let numerator: u64 = input_reserve * output_amount;
+    let denominator: u64 = calculate_amount_with_fee(output_reserve - output_amount);
     numerator / denominator + 1
 }
 

--- a/contracts/swayswap_contract/src/main.sw
+++ b/contracts/swayswap_contract/src/main.sw
@@ -39,6 +39,11 @@ fn key_deposits(a: Address, asset_id: b256) -> b256 {
     hash_pair(S_DEPOSITS, inner, HashMethod::Sha256)
 }
 
+/// Return the token balance for the contract
+fn get_current_balance(token_id: b256) -> u64 {
+    this_balance(~ContractId::from(token_id))
+}
+
 /// Pricing function for converting between ETH and Tokens.
 fn get_input_price(input_amount: u64, input_reserve: u64, output_reserve: u64) -> u64 {
     assert(input_reserve > 0 && output_reserve > 0);
@@ -106,7 +111,6 @@ impl Exchange for Contract {
     }
 
     fn add_liquidity(min_liquidity: u64, max_tokens: u64, deadline: u64) -> u64 {
-        // No coins should be sent with this call. Coins should instead be `deposit`ed prior.
         assert(msg_amount() == 0);
         assert(deadline > height());
         assert(max_tokens > 0);
@@ -128,9 +132,9 @@ impl Exchange for Contract {
         if total_liquidity > 0 {
             assert(min_liquidity > 0);
 
-            let eth_reserve = this_balance(~ContractId::from(ETH_ID));
-            let token_reserve = this_balance(~ContractId::from(TOKEN_ID));
-            let token_amount = (eth_amount * token_reserve) / eth_reserve;
+            let eth_reserve = get_current_balance(ETH_ID) - eth_amount;
+            let token_reserve = get_current_balance(TOKEN_ID);
+            let token_amount = (eth_amount * token_reserve) / eth_reserve + 1;
             let liquidity_minted = (eth_amount * total_liquidity) / eth_reserve;
 
             assert(max_tokens >= token_amount);
@@ -149,7 +153,7 @@ impl Exchange for Contract {
             assert(eth_amount > MINIMUM_LIQUIDITY);
 
             let token_amount = max_tokens;
-            let initial_liquidity = this_balance(~ContractId::from(ETH_ID));
+            let initial_liquidity = get_current_balance(ETH_ID);
             assert(current_token_amount >= token_amount);
 
             mint(initial_liquidity);
@@ -176,9 +180,8 @@ impl Exchange for Contract {
         let total_liquidity = storage.lp_token_supply;
         assert(total_liquidity > 0);
 
-        let eth_reserve = this_balance(~ContractId::from(ETH_ID));
-        let token_reserve = this_balance(~ContractId::from(TOKEN_ID));
-
+        let eth_reserve = get_current_balance(ETH_ID);
+        let token_reserve = get_current_balance(TOKEN_ID);
         let eth_amount = (msg_amount() * eth_reserve) / total_liquidity;
         let token_amount = (msg_amount() * token_reserve) / total_liquidity;
 
@@ -197,46 +200,50 @@ impl Exchange for Contract {
     }
 
     fn swap_with_minimum(min: u64, deadline: u64) -> u64 {
+        let asset_id = (msg_asset_id()).into();
+        let fowarded_amount = msg_amount();
+
         assert(deadline >= height());
-        assert(msg_amount() > 0 && min > 0);
-        assert((msg_asset_id()).into() == ETH_ID || (msg_asset_id()).into() == TOKEN_ID);
+        assert(fowarded_amount > 0 && min > 0);
+        assert(asset_id == ETH_ID || asset_id == TOKEN_ID);
 
         let sender = get_msg_sender_address_or_panic();
 
-        let eth_reserve = this_balance(~ContractId::from(ETH_ID));
-        let token_reserve = this_balance(~ContractId::from(TOKEN_ID));
+        let eth_reserve = get_current_balance(ETH_ID);
+        let token_reserve = get_current_balance(TOKEN_ID);
 
         let mut bought = 0;
-        if ((msg_asset_id()).into() == ETH_ID) {
-            let tokens_bought = get_input_price(msg_amount(), eth_reserve, token_reserve);
+        if (asset_id == ETH_ID) {
+            let tokens_bought = get_input_price(fowarded_amount, eth_reserve, token_reserve);
             assert(tokens_bought >= min);
             transfer_to_output(tokens_bought, ~ContractId::from(TOKEN_ID), sender);
             bought = tokens_bought;
         } else {
-            let eth_bought = get_input_price(msg_amount(), token_reserve, eth_reserve);
+            let eth_bought = get_input_price(fowarded_amount, token_reserve, eth_reserve);
             assert(eth_bought >= min);
             transfer_to_output(eth_bought, ~ContractId::from(ETH_ID), sender);
             bought = eth_bought;
         };
-
         bought
     }
 
     fn swap_with_maximum(amount: u64, deadline: u64) -> u64 {
+        let asset_id = (msg_asset_id()).into();
+        let fowarded_amount = msg_amount();
+
         assert(deadline >= height());
-        assert(amount > 0 && msg_amount() > 0);
-        assert((msg_asset_id()).into() == ETH_ID || (msg_asset_id()).into() == TOKEN_ID);
+        assert(amount > 0 && fowarded_amount > 0);
+        assert(asset_id == ETH_ID || asset_id == TOKEN_ID);
 
         let sender = get_msg_sender_address_or_panic();
-
-        let eth_reserve = this_balance(~ContractId::from(ETH_ID));
-        let token_reserve = this_balance(~ContractId::from(TOKEN_ID));
+        let eth_reserve = get_current_balance(ETH_ID);
+        let token_reserve = get_current_balance(TOKEN_ID);
 
         let mut sold = 0;
-        if ((msg_asset_id()).into() == ETH_ID) {
+        if (asset_id == ETH_ID) {
             let eth_sold = get_output_price(amount, eth_reserve, token_reserve);
-            assert(msg_amount() >= eth_sold);
-            let refund = msg_amount() - eth_sold;
+            assert(fowarded_amount >= eth_sold);
+            let refund = fowarded_amount - eth_sold;
             if refund > 0 {
                 transfer_to_output(refund, ~ContractId::from(ETH_ID), sender);
             };
@@ -244,8 +251,8 @@ impl Exchange for Contract {
             sold = eth_sold;
         } else {
             let tokens_sold = get_output_price(amount, token_reserve, eth_reserve);
-            assert(msg_amount() >= tokens_sold);
-            let refund = msg_amount() - tokens_sold;
+            assert(fowarded_amount >= tokens_sold);
+            let refund = fowarded_amount - tokens_sold;
             if refund > 0 {
                 transfer_to_output(refund, ~ContractId::from(TOKEN_ID), sender);
             };
@@ -256,35 +263,35 @@ impl Exchange for Contract {
     }
 
     fn get_info() -> PoolInfo {
-        let eth_reserve = this_balance(~ContractId::from(ETH_ID));
-        let token_reserve = this_balance(~ContractId::from(TOKEN_ID));
         PoolInfo {
-            eth_reserve: eth_reserve,
-            token_reserve: token_reserve,
+            eth_reserve: get_current_balance(ETH_ID),
+            token_reserve: get_current_balance(TOKEN_ID),
         }
     }
 
-    fn swap_with_minimum_min_value(amount_to_forward: u64) -> u64 {
-        let eth_reserve = this_balance(~ContractId::from(ETH_ID));
-        let token_reserve = this_balance(~ContractId::from(TOKEN_ID));
+    fn get_swap_with_minimum() -> u64 {
+        let eth_reserve = get_current_balance(ETH_ID);
+        let token_reserve = get_current_balance(TOKEN_ID);
+        let amount = msg_amount();
         let mut sold = 0;
         if ((msg_asset_id()).into() == ETH_ID) {
-            sold = get_input_price(amount_to_forward, eth_reserve, token_reserve);
+            sold = get_input_price(amount, eth_reserve, token_reserve);
         } else {
-            sold = get_input_price(amount_to_forward, token_reserve, eth_reserve);
-        };
+            sold = get_input_price(amount, token_reserve, eth_reserve);
+        }
         sold
     }
 
-    fn swap_with_maximum_forward_amount(amount_to_receive: u64) -> u64 {
-        let eth_reserve = this_balance(~ContractId::from(ETH_ID));
-        let token_reserve = this_balance(~ContractId::from(TOKEN_ID));
+    fn get_swap_with_maximum() -> u64 {
+        let eth_reserve = get_current_balance(ETH_ID);
+        let token_reserve = get_current_balance(TOKEN_ID);
+        let amount = msg_amount();
         let mut sold = 0;
         if ((msg_asset_id()).into() == ETH_ID) {
-            sold = get_output_price(amount_to_receive, eth_reserve, token_reserve);
+            sold = get_output_price(amount, eth_reserve, token_reserve);
         } else {
-            sold = get_output_price(amount_to_receive, token_reserve, eth_reserve);
-        };
+            sold = get_output_price(amount, token_reserve, eth_reserve);
+        }
         sold
     }
 }

--- a/contracts/token_contract/Forc.lock
+++ b/contracts/token_contract/Forc.lock
@@ -4,16 +4,16 @@ dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.11.0#95816e4e41aae1d3425ba6ff5e7266076d8400fa'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.12.1#a03a5d1c068a91779e5ce08eead6c4626de2eb0d'
 dependencies = ['core']
 
 [[package]]
 name = 'token_abi'
-dependencies = ['std git+https://github.com/fuellabs/sway?tag=v0.11.0#95816e4e41aae1d3425ba6ff5e7266076d8400fa']
+dependencies = ['std git+https://github.com/fuellabs/sway?tag=v0.12.1#a03a5d1c068a91779e5ce08eead6c4626de2eb0d']
 
 [[package]]
 name = 'token_contract'
 dependencies = [
-    'std git+https://github.com/fuellabs/sway?tag=v0.11.0#95816e4e41aae1d3425ba6ff5e7266076d8400fa',
+    'std git+https://github.com/fuellabs/sway?tag=v0.12.1#a03a5d1c068a91779e5ce08eead6c4626de2eb0d',
     'token_abi',
 ]

--- a/docker/fuel-core/Dockerfile
+++ b/docker/fuel-core/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/fuellabs/fuel-core:v0.6.1
+FROM ghcr.io/fuellabs/fuel-core:v0.6.3
 
 ARG IP=0.0.0.0
 ARG PORT=4000

--- a/docker/fuel-core/chainConfig.json
+++ b/docker/fuel-core/chainConfig.json
@@ -1,7 +1,9 @@
 {
   "chain_name": "local_testnet",
   "block_production": "Instant",
-  "parent_network": { "type": "LocalTest" },
+  "parent_network": {
+    "type": "LocalTest"
+  },
   "initial_state": {
     "coins": [
       {


### PR DESCRIPTION
This PR fixes swap with minimum and maximum. We had an issue when simulating max/min amounts we pass the value as a param to the method. But on `swap` execution the value is `forwarded` changing the result of `this_balance` and also the calculations of `get_input_price` and `get_output_price`.

[feat: change fee calculation for swap](https://github.com/FuelLabs/swayswap/pull/81/commits/5ab31dc0022b90a7df8c8670f9c96f870684ff06)
- We change fee calculation from using multiplication of numbers to `1000` and `997`. To a fee price approximation using the `amount` divided by `333`. Ex.: `1_000_000_000/333 = 3003003` that is near of `3000000`.

[chore: reduce decimal numbers to 3](https://github.com/FuelLabs/swayswap/pull/81/commits/51d4d1300242d784b72755b90513e4d4bc8fd69f)
- Reduce to 3 decimals to better UX, this is a limitation due to `u64` number sizes. We will be able to have bigger precisions when the work on [`u128` is completed](https://github.com/FuelLabs/sway/issues/1478).