### PR TITLE
fix: swap page and coin input

### DIFF
--- a/client/scripts/build-contracts.sh
+++ b/client/scripts/build-contracts.sh
@@ -14,4 +14,4 @@ forc build -p $TOKEN_CONTRACT
 echo "Build Types for contract"
 npx typechain --target fuels --out-dir=./src/types/contracts '../contracts/**/out/debug/**.json'
 echo "Prettify codes"
-npm run prettier-format
+npx prettier --write src/types

--- a/client/src/components/CoinInput.tsx
+++ b/client/src/components/CoinInput.tsx
@@ -72,6 +72,7 @@ export function useCoinInput({
   showBalance = true,
   coin,
   gasFee,
+  onInput,
   ...params
 }: UseCoinParams) {
   const [amount, setAmount] = useState<bigint | null>(null);
@@ -96,6 +97,7 @@ export function useCoinInput({
       isReadOnly,
       value: formatValue(amount),
       displayType: (isReadOnly ? "text" : "input") as DisplayType,
+      onInput,
       onChange: (val: string) => {
         if (isReadOnly) return;
         const next = val !== "" ? parseValueBigInt(val) : null;
@@ -105,6 +107,7 @@ export function useCoinInput({
         return parseValueBigInt(value) <= MAX_U64_VALUE;
       },
       setMaxBalance: () => {
+        onInput?.();
         setAmount(getSafeMaxBalance());
       },
       balance: formatValue(coinBalance?.amount || BigInt(0)),

--- a/client/src/pages/SwapPage/SwapComponent.tsx
+++ b/client/src/pages/SwapPage/SwapComponent.tsx
@@ -64,7 +64,7 @@ export function SwapComponent({
   }, [fromInput.amount, toInput.amount, coinFrom, coinTo]);
 
   useEffect(() => {
-    if (!previewValue) return;
+    if (previewValue == null) return;
     if (activeInput.current === ActiveInput.from) {
       toInput.setAmount(previewValue);
     } else {

--- a/client/src/pages/SwapPage/index.tsx
+++ b/client/src/pages/SwapPage/index.tsx
@@ -58,7 +58,12 @@ export default function SwapPage() {
   );
 
   const shouldDisableButton =
-    isLoading || isSwaping || !swapState || !hasLiquidity || !previewAmount;
+    isLoading ||
+    isSwaping ||
+    !swapState ||
+    !hasLiquidity ||
+    !previewAmount ||
+    !swapState.amount;
 
   const getButtonText = () => {
     if (!hasLiquidity) return "Insufficient liquidity";


### PR DESCRIPTION
- Fix CoinInput to call `onInput` when clicking on `max`
- Fix Preview value to set 0 amount
- Disable the button on swap page if amounts are set to null