### PR TITLE
ci: add action for validate pull request

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,43 @@
+name: "Validate PR"
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, edited, closed]
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Pull request title check
+        uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Cache PNPM modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v2.1.0
+        with:
+          version: 7.0.0
+          run_install: true
+
+      - name: Lint & Test
+        run: |
+          pnpm lint
+          pnpm test

--- a/README.md
+++ b/README.md
@@ -17,54 +17,65 @@ About the project
 
 <!-- 1. [Set up your environment](#set-up-env-variables) -->
 
-A prerequisite for installing and using Sway is the Rust toolchain.  Platform-specific instructions can be found [here](https://www.rust-lang.org/tools/install)
+A prerequisite for installing and using Sway is the Rust toolchain. Platform-specific instructions can be found [here](https://www.rust-lang.org/tools/install)
 
-Installing `fuel-core` may require installing additional system dependencies.  Instructions can be found [here](https://github.com/FuelLabs/fuel-core#building)
+Installing `fuel-core` may require installing additional system dependencies. Instructions can be found [here](https://github.com/FuelLabs/fuel-core#building)
 
-A prerequisite for running a fuel node is docker.  Platform-specific installation instructions can be found [here](https://docs.docker.com/get-docker/)
+A prerequisite for running a fuel node is docker. Platform-specific installation instructions can be found [here](https://docs.docker.com/get-docker/)
 
 The Sway toolchain and Fuel Core full node can be installed with:
+
 ```
 cargo install forc fuel-core
 ```
-`forc` and `fuel-core` are built and tested against the stable Rust toolchain version 1.5.8 or later.  IF your install fails the first time, use `rustup update` and try again.
+
+`forc` and `fuel-core` are built and tested against the stable Rust toolchain version 1.5.8 or later. IF your install fails the first time, use `rustup update` and try again.
 
 There is no guarantee that either package will work with the `nightly` Rust toolchain, so ensure you are using `stable` with:
+
 ```
 rustup default stable
 ```
 
-This project uses pnpm for managing packages and dependencies.  pnpm can be installed with:
+This project uses pnpm for managing packages and dependencies. pnpm can be installed with:
+
 ```
 npm install -g pnpm
 ```
 
 You can install the project dependencies by running the following command in the root directory.
+
 ```
 pnpm install
 ```
 
 A fuel node can be run locally with:
+
 ```
 docker compose up
 ```
 
 Compile the Sway libraries and contracts located in the `/contracts` directory with:
+
 ```
 pnpm build-contracts
 ```
-This command also builds Sway type information for the frontend to use.  The types can be found in the `/packages/app/src/types` directory.
+
+This command also builds Sway type information for the frontend to use. The types can be found in the `/packages/app/src/types` directory.
 
 Deploy the swayswap exhance and token contracts to the fuel network locally with:
+
 ```
 pnpm deploy-contracts
 ```
-This command also creates a temporary wallet and sends some coins to your wallet.  Copy and paste the swayswap contract id and token contract id into the .env.example file.
+
+This command also creates a temporary wallet and sends some coins to your wallet. Copy and paste the swayswap contract id and token contract id into the .env.example file.
 
 For information about running the client go [here](./packages/app/README.md)
 
 ## Setup Env Variables
-After installing the client dependencies in `/packages/app` the contents of `.env.example` are automatically copied to `.env`.  In `.env` we have:
+
+After installing the client dependencies in `/packages/app` the contents of `.env.example` are automatically copied to `.env`. In `.env` we have:
 
 VITE_FUEL_PROVIDER_URL - Link for the fuel node
 
@@ -91,6 +102,7 @@ TODO: https://github.com/FuelLabs/swayswap/issues/54
 -->
 
 ## Project Structure
+
 `/contracts` contains all of the Sway libraries and contracts used in this project.
 
 `/docker` contains the files necessary to run a fuel node locally.

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -18,7 +18,8 @@ Install all dependencies with pnpm
 ```bash
 pnpm install
 ```
-This command also copies the contents of .env.example in a newly created .env file, which the frontend will use to interact with your deployed contracts.  Before starting the development server make sure the contract id and token id environment variables are set to the corresponding contract addresses.
+
+This command also copies the contents of .env.example in a newly created .env file, which the frontend will use to interact with your deployed contracts. Before starting the development server make sure the contract id and token id environment variables are set to the corresponding contract addresses.
 
 Then, run the development server:
 
@@ -31,6 +32,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 You can start editing the pages by modifying `src/pages`. The page auto-updates as you edit the file.
 
 ## Project Structure
+
 `/deploy-contracts` contains code to deploy the swayswap and token contracts, and create and fund a wallet.
 
 `/public` contains publicly accessible assets.


### PR DESCRIPTION
## Problem

Since we are generating changelogs based on conventional commits, when we are squashing pull requests without the right title we are lost a lot of information when generating our changelogs.

## Solution

This pull request just adds a Github action that validates the title according to conventional commits and also checks lint and tests.