### PR TITLE
fix(PoolPage): handle error feedback (getting stuck in Provide Liquidity stage)

### DIFF
--- a/packages/app/src/pages/PoolPage/AddLiquidity.tsx
+++ b/packages/app/src/pages/PoolPage/AddLiquidity.tsx
@@ -153,7 +153,11 @@ export default function AddLiquidity() {
     },
     {
       onSuccess: () => {
-        toast.success(reservesFromToRatio ? "Added liquidity to the pool." : "New pool created.");
+        toast.success(
+          reservesFromToRatio
+            ? "Added liquidity to the pool."
+            : "New pool created."
+        );
         fromInput.setAmount(BigInt(0));
         toInput.setAmount(BigInt(0));
       },
@@ -163,15 +167,18 @@ export default function AddLiquidity() {
         if (errors?.length) {
           if (errors[0].message === "enough coins could not be found") {
             toast.error(
-              `Not enough balance in your wallet to ${reservesFromToRatio ? "add liquidity to" : "create"} this pool.`
+              `Not enough balance in your wallet to ${
+                reservesFromToRatio ? "add liquidity to" : "create"
+              } this pool.`
             );
           }
         } else {
           toast.error(
-            `Error when trying to ${reservesFromToRatio ? "add liquidity to" : "create"} this pool.`
+            `Error when trying to ${
+              reservesFromToRatio ? "add liquidity to" : "create"
+            } this pool.`
           );
         }
-
       },
       onSettled: async () => {
         await refetchPoolInfo();

--- a/packages/app/src/pages/PoolPage/AddLiquidity.tsx
+++ b/packages/app/src/pages/PoolPage/AddLiquidity.tsx
@@ -153,24 +153,30 @@ export default function AddLiquidity() {
     },
     {
       onSuccess: () => {
-        toast.success("New pool created!");
+        toast.success(reservesFromToRatio ? "Added liquidity to the pool." : "New pool created.");
         fromInput.setAmount(BigInt(0));
         toInput.setAmount(BigInt(0));
-        refetchPoolInfo();
-        balances.refetch();
       },
       onError: (e: any) => {
         const errors = e?.response?.errors;
 
-        if (errors.length) {
+        if (errors?.length) {
           if (errors[0].message === "enough coins could not be found") {
             toast.error(
-              "Not enough balance in your wallet to create this pool."
+              `Not enough balance in your wallet to ${reservesFromToRatio ? "add liquidity to" : "create"} this pool.`
             );
           }
+        } else {
+          toast.error(
+            `Error when trying to ${reservesFromToRatio ? "add liquidity to" : "create"} this pool.`
+          );
         }
+
       },
-      onSettled: () => {
+      onSettled: async () => {
+        await refetchPoolInfo();
+        await balances.refetch();
+
         setStage(0);
       },
     }


### PR DESCRIPTION
- User won't get stuck when there's any error
- Show general feedback message + send user back to initial stage of PoolPage
- Improve success / error feedback message

Closes #141 