### PR TITLE
fix: add prod env variables due to vercel issues

### DIFF
--- a/packages/app/.env.production
+++ b/packages/app/.env.production
@@ -1,0 +1,10 @@
+#
+# Production env file
+# This was added due to vercel issues on updating env variables
+#
+VITE_FUEL_PROVIDER_URL=https://node.swayswap.io/graphql
+VITE_CONTRACT_ID=0xac01cffc1fe91976228834078e888efcd185d6792bd2138b09afbdf833599ef6
+VITE_TOKEN_ID=0xb72c566e5a9f69c98298a04d70a38cb32baca4d9b280da8590e0314fb00c59e0
+VITE_RECAPTCHA_SITE_KEY=6Ld3cEwfAAAAAMd4QTs7aO85LyKGdgj0bFsdBfre
+VITE_FUEL_FAUCET_URL=https://faucet-fuel-core.swayswap.io/dispense
+REACT_APP_ENABLE_FAUCET_API=false


### PR DESCRIPTION
Due to issues with cache and bad management of env variables on vercel. We should add .env file on the repo.