### PR TITLE
fix(PoolPage): improve add_liquidity contract

### DIFF
--- a/contracts/exchange_abi/src/main.sw
+++ b/contracts/exchange_abi/src/main.sw
@@ -26,7 +26,7 @@ abi Exchange {
     /// Withdraw coins that have not been added to a liquidity pool yet.
     fn withdraw(amount: u64, asset_id: ContractId);
     /// Deposit ETH and Tokens at current ratio to mint SWAYSWAP tokens.
-    fn add_liquidity(min_liquidity: u64, max_tokens: u64, deadline: u64) -> u64;
+    fn add_liquidity(min_liquidity: u64, deadline: u64) -> u64;
     /// Burn SWAYSWAP tokens to withdraw ETH and Tokens at current ratio.
     fn remove_liquidity(min_eth: u64, min_tokens: u64, deadline: u64) -> RemoveLiquidityReturn;
     /// Swap ETH <-> Tokens and tranfers to sender.

--- a/packages/app/.env.production
+++ b/packages/app/.env.production
@@ -3,7 +3,7 @@
 # This was added due to vercel issues on updating env variables
 #
 VITE_FUEL_PROVIDER_URL=https://node.swayswap.io/graphql
-VITE_CONTRACT_ID=0xe41f5af55af0e8957412c360ef80e2adbf9c2df6d1650ee3da0d86f0072a461f
+VITE_CONTRACT_ID=0x857ce31dad60ad632b5d9694d3ea3fab93b38bb28837be08664c7dde7d30706a
 VITE_TOKEN_ID=0xb72c566e5a9f69c98298a04d70a38cb32baca4d9b280da8590e0314fb00c59e0
 VITE_RECAPTCHA_SITE_KEY=6Ld3cEwfAAAAAMd4QTs7aO85LyKGdgj0bFsdBfre
 VITE_FUEL_FAUCET_URL=https://faucet-fuel-core.swayswap.io/dispense

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -16,6 +16,7 @@ export const RECAPTCHA_SITE_KEY = process.env.VITE_RECAPTCHA_SITE_KEY!;
 export const ENABLE_FAUCET_API = process.env.VITE_ENABLE_FAUCET_API === 'true';
 export const SLIPPAGE_TOLERANCE = 0.005;
 export const NETWORK_FEE = 1;
+export const DEADLINE = 5000;
 
 // Max value supported
 // eslint-disable-next-line @typescript-eslint/no-loss-of-precision

--- a/packages/app/src/hooks/useAddLiquidity.ts
+++ b/packages/app/src/hooks/useAddLiquidity.ts
@@ -6,7 +6,7 @@ import type { UseQueryResult } from 'react-query';
 import { useBalances } from './useBalances';
 
 import type { UseCoinInput } from '~/components/CoinInput';
-import { DEADLINE, SLIPPAGE_TOLERANCE } from '~/config';
+import { DEADLINE } from '~/config';
 import { useContract } from '~/context/AppContext';
 import type { Coin } from '~/types';
 import type { PoolInfo } from '~/types/contracts/Exchange_contractAbi';
@@ -64,7 +64,6 @@ export function useAddLiquidity({
       onSuccess: (liquidityTokens) => {
         if (liquidityTokens) {
           toast.success(reservesFromToRatio ? 'Added liquidity to the pool.' : 'New pool created.');
-
         } else {
           toast.error(
             `Error when trying to ${reservesFromToRatio ? 'add liquidity to' : 'create'} this pool.`

--- a/packages/app/src/pages/PoolPage/AddLiquidity.tsx
+++ b/packages/app/src/pages/PoolPage/AddLiquidity.tsx
@@ -9,6 +9,7 @@ import { RiCheckFill } from "react-icons/ri";
 import { poolFromAmountAtom, poolToAmountAtom } from "./jotai";
 
 import { Button } from "~/components/Button";
+import { Card } from "~/components/Card";
 import { CoinInput, useCoinInput } from "~/components/CoinInput";
 import { CoinSelector } from "~/components/CoinSelector";
 import { PreviewItem, PreviewTable } from "~/components/PreviewTable";
@@ -150,103 +151,120 @@ export default function AddLiquidity() {
     contractId: CONTRACT_ID,
   });
 
-  return addLiquidityMutation.isLoading ? (
-    <div className="mt-6 mb-8 flex justify-center">
-      <PoolLoader
-        steps={[
-          `Deposit: ${coinFrom.name}`,
-          `Deposit: ${coinTo.name}`,
-          `Provide liquidity`,
-          `Done`,
-        ]}
-        step={stage}
-        loading={addLiquidityMutation.isLoading}
-        coinFrom={coinFrom}
-        coinTo={coinTo}
-      />
-    </div>
-  ) : (
-    <>
-      <div className="mt-6 mb-4">
-        <CoinInput
-          {...fromInput.getInputProps()}
-          rightElement={<CoinSelector {...fromInput.getCoinSelectorProps()} />}
-          autoFocus
-        />
-      </div>
-      <div className="mb-6">
-        <CoinInput
-          {...toInput.getInputProps()}
-          rightElement={<CoinSelector {...toInput.getCoinSelectorProps()} />}
-        />
-      </div>
-      {!!addLiquidityRatio && (
-        <PreviewTable title="Expected output:" className="my-2">
-          <PreviewItem
-            title="Pool tokens you'll receive:"
-            value={formatUnits(previewTokensToReceive, DECIMAL_UNITS)}
+  return (
+    <Card>
+      <Card.Title>Add Liquidity</Card.Title>
+      {addLiquidityMutation.isLoading ? (
+        <div className="mt-6 mb-8 flex justify-center">
+          <PoolLoader
+            steps={[
+              `Deposit: ${coinFrom.name}`,
+              `Deposit: ${coinTo.name}`,
+              `Provide liquidity`,
+              `Done`,
+            ]}
+            step={stage}
+            loading={addLiquidityMutation.isLoading}
+            coinFrom={coinFrom}
+            coinTo={coinTo}
           />
-          <PreviewItem
-            title={"Your share of current pool:"}
-            value={`${parseFloat((nextCurrentPoolShare * 100).toFixed(6))}%`}
-          />
-        </PreviewTable>
-      )}
-      {poolInfo && reservesFromToRatio ? (
-        <div className={style.info}>
-          <h4 className="text-white mb-2 font-bold">Reserves</h4>
-          <div className="flex">
-            <div className="flex flex-col flex-1">
-              <span>
-                ETH:{" "}
-                {formatUnits(poolInfo.eth_reserve, DECIMAL_UNITS).toString()}
-              </span>
-              <span>
-                DAI:{" "}
-                {formatUnits(poolInfo.token_reserve, DECIMAL_UNITS).toString()}
-              </span>
-            </div>
-            {poolInfo.eth_reserve > 0 && poolInfo.token_reserve > 0 ? (
-              <div className="flex flex-col">
-                <span>
-                  <>ETH/DAI: {reservesFromToRatio.toFixed(6)}</>
-                </span>
-                <span>
-                  <>DAI/ETH: {reservesToFromRatio.toFixed(6)}</>
-                </span>
+        </div>
+      ) : (
+        <>
+          <div className="mt-6 mb-4">
+            <CoinInput
+              {...fromInput.getInputProps()}
+              rightElement={
+                <CoinSelector {...fromInput.getCoinSelectorProps()} />
+              }
+              autoFocus
+            />
+          </div>
+          <div className="mb-6">
+            <CoinInput
+              {...toInput.getInputProps()}
+              rightElement={
+                <CoinSelector {...toInput.getCoinSelectorProps()} />
+              }
+            />
+          </div>
+          {!!addLiquidityRatio && (
+            <PreviewTable title="Expected output:" className="my-2">
+              <PreviewItem
+                title="Pool tokens you'll receive:"
+                value={formatUnits(previewTokensToReceive, DECIMAL_UNITS)}
+              />
+              <PreviewItem
+                title={"Your share of current pool:"}
+                value={`${parseFloat(
+                  (nextCurrentPoolShare * 100).toFixed(6)
+                )}%`}
+              />
+            </PreviewTable>
+          )}
+          {poolInfo && reservesFromToRatio ? (
+            <div className={style.info}>
+              <h4 className="text-white mb-2 font-bold">Reserves</h4>
+              <div className="flex">
+                <div className="flex flex-col flex-1">
+                  <span>
+                    ETH:{" "}
+                    {formatUnits(
+                      poolInfo.eth_reserve,
+                      DECIMAL_UNITS
+                    ).toString()}
+                  </span>
+                  <span>
+                    DAI:{" "}
+                    {formatUnits(
+                      poolInfo.token_reserve,
+                      DECIMAL_UNITS
+                    ).toString()}
+                  </span>
+                </div>
+                {poolInfo.eth_reserve > 0 && poolInfo.token_reserve > 0 ? (
+                  <div className="flex flex-col">
+                    <span>
+                      <>ETH/DAI: {reservesFromToRatio.toFixed(6)}</>
+                    </span>
+                    <span>
+                      <>DAI/ETH: {reservesToFromRatio.toFixed(6)}</>
+                    </span>
+                  </div>
+                ) : null}
               </div>
-            ) : null}
-          </div>
-        </div>
-      ) : null}
-      <Button
-        isDisabled={!!errorsCreatePull.length}
-        isFull
-        size="lg"
-        variant="primary"
-        onPress={
-          errorsCreatePull.length
-            ? undefined
-            : () => addLiquidityMutation.mutate()
-        }
-      >
-        {errorsCreatePull.length
-          ? errorsCreatePull[0]
-          : reservesFromToRatio
-          ? "Add liquidity"
-          : "Create liquidity"}
-      </Button>
-      {!reservesFromToRatio && !isLoadingPoolInfo ? (
-        <div className={style.createPoolInfo}>
-          <h4 className="text-orange-400 mb-2 font-bold">
-            You are creating a new pool
-          </h4>
-          <div className="flex">
-            You are the first to provide liquidity to this pool. The ratio
-            between these tokens will set the price of this pool.
-          </div>
-        </div>
-      ) : null}
-    </>
+            </div>
+          ) : null}
+          <Button
+            isDisabled={!!errorsCreatePull.length}
+            isFull
+            size="lg"
+            variant="primary"
+            onPress={
+              errorsCreatePull.length
+                ? undefined
+                : () => addLiquidityMutation.mutate()
+            }
+          >
+            {errorsCreatePull.length
+              ? errorsCreatePull[0]
+              : reservesFromToRatio
+              ? "Add liquidity"
+              : "Create liquidity"}
+          </Button>
+          {!reservesFromToRatio && !isLoadingPoolInfo ? (
+            <div className={style.createPoolInfo}>
+              <h4 className="text-orange-400 mb-2 font-bold">
+                You are creating a new pool
+              </h4>
+              <div className="flex">
+                You are the first to provide liquidity to this pool. The ratio
+                between these tokens will set the price of this pool.
+              </div>
+            </div>
+          ) : null}
+        </>
+      )}
+    </Card>
   );
 }

--- a/packages/app/src/pages/PoolPage/AddLiquidity.tsx
+++ b/packages/app/src/pages/PoolPage/AddLiquidity.tsx
@@ -132,7 +132,6 @@ export default function AddLiquidity() {
     coinFrom,
     coinTo,
     reservesFromToRatio,
-    addLiquidityRatio,
   });
 
   useEffect(() => {

--- a/packages/app/src/pages/PoolPage/PoolsPreview.tsx
+++ b/packages/app/src/pages/PoolPage/PoolsPreview.tsx
@@ -1,8 +1,10 @@
-import { BiListUl } from "react-icons/bi";
+import cx from "classnames";
+import { BiListUl, BiDollarCircle } from "react-icons/bi";
 import { useNavigate } from "react-router-dom";
 
 import { Accordion } from "~/components/Accordion";
 import { Button } from "~/components/Button";
+import { Card } from "~/components/Card";
 import { PreviewTable, PreviewItem } from "~/components/PreviewTable";
 import { Spinner } from "~/components/Spinner";
 import { TokenIcon } from "~/components/TokenIcon";
@@ -10,6 +12,27 @@ import { usePoolInfo } from "~/hooks/usePoolInfo";
 import { useUserPositions } from "~/hooks/useUserPositions";
 import CoinsMetadata from "~/lib/CoinsMetadata";
 import { Pages } from "~/types/pages";
+
+const style = {
+  button: `relative font-semibold text-xs`,
+};
+
+const SubpagesNav = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex items-center gap-4">
+      <Button
+        size="sm"
+        variant="primary"
+        onPress={() => navigate(`../${Pages["pool.addLiquidity"]}`)}
+        className={cx(style.button)}
+      >
+        Add Liquidity
+      </Button>
+    </div>
+  );
+};
 
 function WithoutPositions() {
   return (
@@ -80,7 +103,11 @@ export default function PoolsPreview() {
   const { hasPositions } = useUserPositions();
 
   return (
-    <div>
+    <Card>
+      <Card.Title elementRight={<SubpagesNav />}>
+        <BiDollarCircle className="text-primary-500" />
+        Pool
+      </Card.Title>
       <h3 className="pb-1 mb-3 mt-5 text-gray-100 border-b border-dashed border-gray-600">
         Your liquidity positions
       </h3>
@@ -91,6 +118,6 @@ export default function PoolsPreview() {
           <PositionItem />
         </Accordion>
       )}
-    </div>
+    </Card>
   );
 }

--- a/packages/app/src/pages/PoolPage/RemoveLiquidity.tsx
+++ b/packages/app/src/pages/PoolPage/RemoveLiquidity.tsx
@@ -5,7 +5,7 @@ import { useMutation } from "react-query";
 import { Button } from "~/components/Button";
 import { CoinInput, useCoinInput } from "~/components/CoinInput";
 import { CoinSelector } from "~/components/CoinSelector";
-import { CONTRACT_ID } from "~/config";
+import { CONTRACT_ID, DEADLINE } from "~/config";
 import { useContract } from "~/context/AppContext";
 import { useBalances } from "~/hooks/useBalances";
 import coins from "~/lib/CoinsMetadata";
@@ -30,7 +30,7 @@ export default function RemoveLiquidityPage() {
       }
       // TODO: Add way to set min_eth and min_tokens
       // https://github.com/FuelLabs/swayswap/issues/55
-      await contract.functions.remove_liquidity(1, 1, 1000, {
+      await contract.functions.remove_liquidity(1, 1, DEADLINE, {
         forward: [amount, CONTRACT_ID],
         variableOutputs: 2,
       });

--- a/packages/app/src/pages/PoolPage/RemoveLiquidity.tsx
+++ b/packages/app/src/pages/PoolPage/RemoveLiquidity.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
+import { BiDollarCircle } from "react-icons/bi";
 import { useMutation } from "react-query";
 
 import { Button } from "~/components/Button";
+import { Card } from "~/components/Card";
 import { CoinInput, useCoinInput } from "~/components/CoinInput";
 import { CoinSelector } from "~/components/CoinSelector";
 import { CONTRACT_ID, DEADLINE } from "~/config";
@@ -84,7 +86,11 @@ export default function RemoveLiquidityPage() {
   };
 
   return (
-    <>
+    <Card>
+      <Card.Title>
+        <BiDollarCircle className="text-primary-500" />
+        Remove Liquidity
+      </Card.Title>
       <div className="mt-4 mb-4">
         <CoinInput
           {...tokenInput.getInputProps()}
@@ -105,6 +111,6 @@ export default function RemoveLiquidityPage() {
       >
         {getButtonText()}
       </Button>
-    </>
+    </Card>
   );
 }

--- a/packages/app/src/pages/PoolPage/index.tsx
+++ b/packages/app/src/pages/PoolPage/index.tsx
@@ -1,35 +1,12 @@
-import cx from "classnames";
 import { BiDollarCircle } from "react-icons/bi";
-import { Outlet, useNavigate } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 
-import { Button } from "~/components/Button";
 import { Card } from "~/components/Card";
-
-const style = {
-  button: `relative font-semibold text-xs`,
-};
-
-const SubpagesNav = () => {
-  const navigate = useNavigate();
-
-  return (
-    <div className="flex items-center gap-4">
-      <Button
-        size="sm"
-        variant="primary"
-        onPress={() => navigate("add-liquidity")}
-        className={cx(style.button)}
-      >
-        Add Liquidity
-      </Button>
-    </div>
-  );
-};
 
 export default function PoolPage() {
   return (
     <Card>
-      <Card.Title elementRight={<SubpagesNav />}>
+      <Card.Title>
         <BiDollarCircle className="text-primary-500" />
         Pool
       </Card.Title>

--- a/packages/app/src/pages/PoolPage/index.tsx
+++ b/packages/app/src/pages/PoolPage/index.tsx
@@ -1,16 +1,5 @@
-import { BiDollarCircle } from "react-icons/bi";
 import { Outlet } from "react-router-dom";
 
-import { Card } from "~/components/Card";
-
 export default function PoolPage() {
-  return (
-    <Card>
-      <Card.Title>
-        <BiDollarCircle className="text-primary-500" />
-        Pool
-      </Card.Title>
-      <Outlet />
-    </Card>
-  );
+  return <Outlet />;
 }

--- a/packages/app/src/types/contracts/Exchange_contractAbi.d.ts
+++ b/packages/app/src/types/contracts/Exchange_contractAbi.d.ts
@@ -61,7 +61,7 @@ interface Exchange_contractAbiInterface extends Interface {
   encodeFunctionData(functionFragment: 'withdraw', values: [BigNumberish, ContractIdInput]): string;
   encodeFunctionData(
     functionFragment: 'add_liquidity',
-    values: [BigNumberish, BigNumberish, BigNumberish]
+    values: [BigNumberish, BigNumberish]
   ): string;
   encodeFunctionData(
     functionFragment: 'remove_liquidity',
@@ -109,7 +109,6 @@ export class Exchange_contractAbi extends Contract {
 
     add_liquidity(
       min_liquidity: BigNumberish,
-      max_tokens: BigNumberish,
       deadline: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<bigint>;
@@ -161,7 +160,6 @@ export class Exchange_contractAbi extends Contract {
 
     add_liquidity(
       min_liquidity: BigNumberish,
-      max_tokens: BigNumberish,
       deadline: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<bigint>;
@@ -213,7 +211,6 @@ export class Exchange_contractAbi extends Contract {
 
   add_liquidity(
     min_liquidity: BigNumberish,
-    max_tokens: BigNumberish,
     deadline: BigNumberish,
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<bigint>;

--- a/packages/app/src/types/contracts/factories/Exchange_contractAbi__factory.ts
+++ b/packages/app/src/types/contracts/factories/Exchange_contractAbi__factory.ts
@@ -80,11 +80,6 @@ const _abi = [
         components: null,
       },
       {
-        name: 'max_tokens',
-        type: 'u64',
-        components: null,
-      },
-      {
         name: 'deadline',
         type: 'u64',
         components: null,


### PR DESCRIPTION
- contract changes
  - add_liquidity
    - use always contract user balance, instead of front-end value
    - if tokens ratio is wrong, contract won't break anymore. Instead we return the previous depositted user balances to his wallet
    - if tokens ratio is ok, should return any leftover token to user wallet
  - get_balance
    - return user contract balance, instead of whole contract balance



- frontend changes
  - PoolPage - Add Liquidity - removed ratio validation from front-end, as contract is already handling it now
  - increased deadline to 5000 in remove_liquidity and add_liquidity
  - created config param for contracts Deadline


Closes #200 