### PR TITLE
feat(AddLiquidityPage): add preview + current pool reserves

### DIFF
--- a/packages/app/src/hooks/useEthBalance.ts
+++ b/packages/app/src/hooks/useEthBalance.ts
@@ -1,9 +1,8 @@
-import { formatUnits } from 'ethers/lib/utils';
-
 import { useBalances } from './useBalances';
 
 import { DECIMAL_UNITS } from '~/config';
 import CoinsMetadata from '~/lib/CoinsMetadata';
+import { parseToFormattedNumber } from '~/lib/utils';
 
 const ETH_ID = CoinsMetadata.find((item) => item.symbol === 'ETH')?.assetId;
 
@@ -12,6 +11,6 @@ export function useEthBalance() {
   const balance = balances?.find((item) => item.assetId === ETH_ID)?.amount;
   return {
     raw: balance,
-    formatted: balance && formatUnits(balance, DECIMAL_UNITS),
+    formatted: balance && parseToFormattedNumber(balance, DECIMAL_UNITS),
   };
 }

--- a/packages/app/src/hooks/useUserPositions.tsx
+++ b/packages/app/src/hooks/useUserPositions.tsx
@@ -1,4 +1,3 @@
-import { formatUnits } from "ethers/lib/utils";
 import { toNumber } from "fuels";
 
 import { useBalances } from "./useBalances";
@@ -6,7 +5,7 @@ import { usePoolInfo } from "./usePoolInfo";
 
 import { DECIMAL_UNITS } from "~/config";
 import CoinsMetadata from "~/lib/CoinsMetadata";
-import { divideFnValidOnly } from "~/lib/utils";
+import { divideFnValidOnly, parseToFormattedNumber } from "~/lib/utils";
 
 export function useUserPositions() {
   const { data: info } = usePoolInfo();
@@ -23,6 +22,15 @@ export function useUserPositions() {
   const tokenReserve = toNumber(info?.token_reserve || BigInt(0));
   const ethReserve = toNumber(info?.eth_reserve || BigInt(0));
 
+  const formattedTokenReserve = parseToFormattedNumber(
+    Math.floor(tokenReserve),
+    DECIMAL_UNITS
+  );
+  const formattedEthReserve = parseToFormattedNumber(
+    Math.floor(ethReserve),
+    DECIMAL_UNITS
+  );
+
   const pooledDAI = divideFnValidOnly(
     poolTokensNum * tokenReserve,
     totalLiquidity
@@ -31,10 +39,16 @@ export function useUserPositions() {
     poolTokensNum * ethReserve,
     totalLiquidity
   );
-  const formattedPooledDAI = formatUnits(Math.floor(pooledDAI), DECIMAL_UNITS);
-  const formattedPooledETH = formatUnits(Math.floor(pooledETH), DECIMAL_UNITS);
+  const formattedPooledDAI = parseToFormattedNumber(
+    Math.floor(pooledDAI),
+    DECIMAL_UNITS
+  );
+  const formattedPooledETH = parseToFormattedNumber(
+    Math.floor(pooledETH),
+    DECIMAL_UNITS
+  );
   const formattedPoolTokens = poolTokensNum
-    ? formatUnits(poolTokensNum, DECIMAL_UNITS)
+    ? parseToFormattedNumber(poolTokensNum, DECIMAL_UNITS)
     : "0";
 
   const poolShare = poolTokensNum / totalLiquidity;
@@ -51,6 +65,8 @@ export function useUserPositions() {
     formattedPooledETH,
     formattedPoolShare,
     formattedPoolTokens,
+    formattedTokenReserve,
+    formattedEthReserve,
     hasPositions,
     totalLiquidity,
     tokenReserve,

--- a/packages/app/src/lib/utils.ts
+++ b/packages/app/src/lib/utils.ts
@@ -1,8 +1,9 @@
 import { BigNumber } from 'ethers';
+import { commify, formatUnits } from 'ethers/lib/utils';
 import type { BigNumberish } from 'fuels';
 import { urlJoin } from 'url-join-ts';
 
-import { MAX_U64_STRING } from '~/config';
+import { DECIMAL_UNITS, MAX_U64_STRING } from '~/config';
 
 const { PUBLIC_URL } = process.env;
 
@@ -33,3 +34,8 @@ export function divideFnValidOnly(value?: BigNumberish | null, by?: BigNumberish
 
   return Number.isNaN(result) || !Number.isFinite(result) ? 0 : result;
 }
+
+export const parseToFormattedNumber = (
+  value: string | BigNumberish,
+  unit: BigNumberish = DECIMAL_UNITS
+) => commify(formatUnits(value, unit));

--- a/packages/app/src/pages/PoolPage/AddLiquidity.tsx
+++ b/packages/app/src/pages/PoolPage/AddLiquidity.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable no-nested-ternary */
 import classNames from "classnames";
-import { formatUnits } from "ethers/lib/utils";
 import { toNumber } from "fuels";
 import { useAtom } from "jotai";
 import { useEffect, useState } from "react";
 import { RiCheckFill } from "react-icons/ri";
 
+import { AddLiquidityPoolPrice } from "./AddLiquidityPoolPrice";
 import { AddLiquidityPreview } from "./AddLiquidityPreview";
+import { PoolCurrentReserves } from "./PoolCurrentReserves";
 import { poolFromAmountAtom, poolToAmountAtom } from "./jotai";
 
 import { Button } from "~/components/Button";
@@ -14,7 +15,6 @@ import { Card } from "~/components/Card";
 import { CoinInput, useCoinInput } from "~/components/CoinInput";
 import { CoinSelector } from "~/components/CoinSelector";
 import { Spinner } from "~/components/Spinner";
-import { DECIMAL_UNITS } from "~/config";
 import { useAddLiquidity } from "~/hooks/useAddLiquidity";
 import { usePoolInfo } from "~/hooks/usePoolInfo";
 import assets from "~/lib/CoinsMetadata";
@@ -25,7 +25,6 @@ const style = {
   wrapper: `w-screen flex flex-1 items-center justify-center pb-14`,
   content: `bg-gray-800 w-[30rem] rounded-2xl p-4 m-2`,
   formHeader: `px-2 flex items-center justify-between font-semibold text-xl`,
-  info: `font-mono my-4 px-4 py-3 text-sm text-slate-400 decoration-1 border border-dashed border-white/10 rounded-lg`,
   createPoolInfo: `font-mono my-4 px-4 py-3 text-sm text-slate-400 decoration-1 border border-dashed border-white/10 rounded-lg max-w-[400px]`,
 };
 
@@ -114,11 +113,6 @@ export default function AddLiquidity() {
     poolInfo?.token_reserve
   );
 
-  const reservesToFromRatio = divideFnValidOnly(
-    poolInfo?.token_reserve,
-    poolInfo?.eth_reserve
-  );
-
   const addLiquidityRatio = divideFnValidOnly(fromInput.amount, toInput.amount);
 
   const {
@@ -184,39 +178,13 @@ export default function AddLiquidity() {
           {!!addLiquidityRatio && (
             <AddLiquidityPreview poolInfo={poolInfo} fromInput={fromInput} />
           )}
-          {poolInfo && reservesFromToRatio ? (
-            <div className={style.info}>
-              <h4 className="text-white mb-2 font-bold">Reserves</h4>
-              <div className="flex">
-                <div className="flex flex-col flex-1">
-                  <span>
-                    ETH:{" "}
-                    {formatUnits(
-                      poolInfo.eth_reserve,
-                      DECIMAL_UNITS
-                    ).toString()}
-                  </span>
-                  <span>
-                    DAI:{" "}
-                    {formatUnits(
-                      poolInfo.token_reserve,
-                      DECIMAL_UNITS
-                    ).toString()}
-                  </span>
-                </div>
-                {poolInfo.eth_reserve > 0 && poolInfo.token_reserve > 0 ? (
-                  <div className="flex flex-col">
-                    <span>
-                      <>ETH/DAI: {reservesFromToRatio.toFixed(6)}</>
-                    </span>
-                    <span>
-                      <>DAI/ETH: {reservesToFromRatio.toFixed(6)}</>
-                    </span>
-                  </div>
-                ) : null}
-              </div>
-            </div>
-          ) : null}
+          {!!(poolInfo && reservesFromToRatio) && (
+            <AddLiquidityPoolPrice
+              coinFrom={coinFrom}
+              coinTo={coinTo}
+              reservesFromToRatio={reservesFromToRatio}
+            />
+          )}
           <Button
             isDisabled={!!errorsCreatePull.length}
             isFull
@@ -245,6 +213,7 @@ export default function AddLiquidity() {
               </div>
             </div>
           ) : null}
+          {!!(poolInfo && reservesFromToRatio) && <PoolCurrentReserves />}
         </>
       )}
     </Card>

--- a/packages/app/src/pages/PoolPage/AddLiquidityPoolPrice.tsx
+++ b/packages/app/src/pages/PoolPage/AddLiquidityPoolPrice.tsx
@@ -1,0 +1,39 @@
+import { toNumber } from "fuels";
+
+import { ONE_ASSET } from "~/config";
+import { parseToFormattedNumber } from "~/lib/utils";
+import type { Coin } from "~/types";
+
+export interface AddLiquidityPoolPriceProps {
+  coinFrom: Coin;
+  coinTo: Coin;
+  reservesFromToRatio: number;
+}
+
+export const AddLiquidityPoolPrice = ({
+  coinFrom,
+  coinTo,
+  reservesFromToRatio,
+}: AddLiquidityPoolPriceProps) => (
+  <div className="font-mono my-4 px-4 py-3 text-sm text-slate-400">
+    <div className="flex">
+      <h4 className="text-white mb-2 font-bold flex-1">Pool price</h4>
+      <div className="flex flex-col">
+        <span>
+          1 {coinFrom.name} ={" "}
+          {parseToFormattedNumber(
+            Math.floor((toNumber(ONE_ASSET) * 1) / reservesFromToRatio)
+          )}{" "}
+          {coinTo.name}
+        </span>
+        <span>
+          1 {coinTo.name} ={" "}
+          {parseToFormattedNumber(
+            Math.floor(toNumber(ONE_ASSET) * 1 * reservesFromToRatio)
+          )}{" "}
+          {coinFrom.name}
+        </span>
+      </div>
+    </div>
+  </div>
+);

--- a/packages/app/src/pages/PoolPage/AddLiquidityPreview.tsx
+++ b/packages/app/src/pages/PoolPage/AddLiquidityPreview.tsx
@@ -2,6 +2,9 @@ import { usePreviewAddLiquidity } from "./usePreviewAddLiquidity";
 
 import type { UseCoinInput } from "~/components/CoinInput";
 import { PreviewItem, PreviewTable } from "~/components/PreviewTable";
+import { TokenIcon } from "~/components/TokenIcon";
+import { useCoinMetadata } from "~/hooks/useCoinMetadata";
+import { ETH_DAI } from "~/lib/CoinsMetadata";
 import type { PoolInfo } from "~/types/contracts/Exchange_contractAbi";
 
 export interface AddLiquidityPreviewProps {
@@ -13,6 +16,10 @@ export const AddLiquidityPreview = ({
   poolInfo,
   fromInput,
 }: AddLiquidityPreviewProps) => {
+  const { coinMetaData } = useCoinMetadata({ symbol: ETH_DAI.name });
+  const coinFrom = coinMetaData?.pairOf?.[0];
+  const coinTo = coinMetaData?.pairOf?.[1];
+
   const { formattedPreviewTokens, formattedNextCurrentPoolShare } =
     usePreviewAddLiquidity({
       fromInput,
@@ -23,7 +30,12 @@ export const AddLiquidityPreview = ({
     <PreviewTable title="Expected output:" className="my-2">
       <PreviewItem
         title="Pool tokens you'll receive:"
-        value={formattedPreviewTokens}
+        value={
+          <div className="flex flex-1 items-center justify-end">
+            {formattedPreviewTokens}{" "}
+            <TokenIcon coinFrom={coinFrom} coinTo={coinTo} size={14} />
+          </div>
+        }
       />
       <PreviewItem
         title={"Your share of current pool:"}

--- a/packages/app/src/pages/PoolPage/PoolCurrentPosition.tsx
+++ b/packages/app/src/pages/PoolPage/PoolCurrentPosition.tsx
@@ -29,7 +29,15 @@ export const PoolCurrentPosition = () => {
           </div>
         }
       />
-      <PreviewItem title="Your pool tokens" value={info.formattedPoolTokens} />
+      <PreviewItem
+        title="Your pool tokens"
+        value={
+          <div className="flex flex-1 items-center justify-end">
+            {info.formattedPoolTokens}{" "}
+            <TokenIcon coinFrom={coinFrom} coinTo={coinTo} size={14} />
+          </div>
+        }
+      />
       <PreviewItem
         title="Your pool share"
         value={`${info.formattedPoolShare}%`}

--- a/packages/app/src/pages/PoolPage/PoolCurrentReserves.tsx
+++ b/packages/app/src/pages/PoolPage/PoolCurrentReserves.tsx
@@ -1,0 +1,39 @@
+import { PreviewTable, PreviewItem } from "~/components/PreviewTable";
+import { TokenIcon } from "~/components/TokenIcon";
+import { useCoinMetadata } from "~/hooks/useCoinMetadata";
+import { useUserPositions } from "~/hooks/useUserPositions";
+import { ETH_DAI } from "~/lib/CoinsMetadata";
+
+export const PoolCurrentReserves = () => {
+  const { formattedEthReserve, formattedTokenReserve } = useUserPositions();
+  const { coinMetaData } = useCoinMetadata({ symbol: ETH_DAI.name });
+  const coinFrom = coinMetaData?.pairOf?.[0];
+  const coinTo = coinMetaData?.pairOf?.[1];
+
+  return (
+    <PreviewTable title="Current pool reserves" className="my-2 mt-4">
+      <PreviewItem
+        title={
+          <div className="inline-flex items-center gap">
+            <TokenIcon coinFrom={coinFrom} size={14} />
+            <div className="ml-2">
+              {coinFrom?.name}: {formattedEthReserve}
+            </div>
+          </div>
+        }
+        value=""
+      />
+      <PreviewItem
+        title={
+          <div className="inline-flex items-center gap">
+            <TokenIcon coinFrom={coinTo} size={14} />
+            <div className="ml-2">
+              {coinTo?.name}: {formattedTokenReserve}
+            </div>
+          </div>
+        }
+        value=""
+      />
+    </PreviewTable>
+  );
+};

--- a/packages/app/src/pages/PoolPage/Pools.tsx
+++ b/packages/app/src/pages/PoolPage/Pools.tsx
@@ -55,7 +55,7 @@ function PositionItem() {
       <Accordion.Trigger>
         <div className="flex items-center">
           <TokenIcon coinFrom={coinFrom} coinTo={coinTo} />
-          ETH/DAI
+          <div className="ml-2">ETH/DAI</div>
         </div>
       </Accordion.Trigger>
       <Accordion.Content>

--- a/packages/app/src/pages/PoolPage/RemoveLiquidityPreview.tsx
+++ b/packages/app/src/pages/PoolPage/RemoveLiquidityPreview.tsx
@@ -3,6 +3,9 @@ import { BsArrowDown } from "react-icons/bs";
 import { usePreviewRemoveLiquidity } from "./usePreviewRemoveLiquidity";
 
 import { PreviewItem, PreviewTable } from "~/components/PreviewTable";
+import { TokenIcon } from "~/components/TokenIcon";
+import { useCoinMetadata } from "~/hooks/useCoinMetadata";
+import { ETH_DAI } from "~/lib/CoinsMetadata";
 
 export interface RemoveLiquidityPreviewProps {
   amount: bigint | null;
@@ -11,6 +14,9 @@ export interface RemoveLiquidityPreviewProps {
 export const RemoveLiquidityPreview = ({
   amount,
 }: RemoveLiquidityPreviewProps) => {
+  const { coinMetaData } = useCoinMetadata({ symbol: ETH_DAI.name });
+  const coinFrom = coinMetaData?.pairOf?.[0];
+  const coinTo = coinMetaData?.pairOf?.[1];
   const {
     formattedPreviewDAIRemoved,
     formattedPreviewETHRemoved,
@@ -26,11 +32,32 @@ export const RemoveLiquidityPreview = ({
         <BsArrowDown size={24} />
       </div>
       <PreviewTable title="Expected output:" className="my-2 mb-4">
-        <PreviewItem title="DAI:" value={formattedPreviewDAIRemoved} />
-        <PreviewItem title={"ETH:"} value={formattedPreviewETHRemoved} />
+        <PreviewItem
+          title="DAI:"
+          value={
+            <div className="flex flex-1 items-center justify-end">
+              {formattedPreviewDAIRemoved}{" "}
+              <TokenIcon coinFrom={coinTo} size={14} />
+            </div>
+          }
+        />
+        <PreviewItem
+          title={"ETH:"}
+          value={
+            <div className="flex flex-1 items-center justify-end">
+              {formattedPreviewETHRemoved}{" "}
+              <TokenIcon coinFrom={coinFrom} size={14} />
+            </div>
+          }
+        />
         <PreviewItem
           title="Pool tokens after:"
-          value={`${formattedNextCurrentPoolTokens}`}
+          value={
+            <div className="flex flex-1 items-center justify-end">
+              {formattedNextCurrentPoolTokens}{" "}
+              <TokenIcon coinFrom={coinFrom} coinTo={coinTo} size={14} />
+            </div>
+          }
         />
         <PreviewItem
           title="Pool share after:"

--- a/packages/app/src/pages/PoolPage/usePreviewAddLiquidity.ts
+++ b/packages/app/src/pages/PoolPage/usePreviewAddLiquidity.ts
@@ -1,11 +1,10 @@
-import { formatUnits } from 'ethers/lib/utils';
 import { toNumber } from 'fuels';
 
 import { useUserPositions } from '../../hooks/useUserPositions';
 
 import type { UseCoinInput } from '~/components/CoinInput';
 import { DECIMAL_UNITS } from '~/config';
-import { divideFnValidOnly } from '~/lib/utils';
+import { divideFnValidOnly, parseToFormattedNumber } from '~/lib/utils';
 import type { PoolInfo } from '~/types/contracts/Exchange_contractAbi';
 
 export interface UsePreviewLiquidityProps {
@@ -21,7 +20,8 @@ export function usePreviewAddLiquidity({ fromInput, poolInfo }: UsePreviewLiquid
   const nextCurrentPoolShare =
     divideFnValidOnly(BigInt(previewTokens + poolTokensNum), BigInt(nextTotalTokenSupply)) || 1;
 
-  const formattedPreviewTokens = formatUnits(previewTokens, DECIMAL_UNITS);
+  const formattedPreviewTokens = parseToFormattedNumber(previewTokens, DECIMAL_UNITS);
+
   const formattedNextCurrentPoolShare = parseFloat((nextCurrentPoolShare * 100).toFixed(6));
 
   return {

--- a/packages/app/src/pages/PoolPage/usePreviewRemoveLiquidity.ts
+++ b/packages/app/src/pages/PoolPage/usePreviewRemoveLiquidity.ts
@@ -1,9 +1,8 @@
-import { formatUnits } from 'ethers/lib/utils';
 import { toNumber } from 'fuels';
 
 import { DECIMAL_UNITS } from '~/config';
 import { useUserPositions } from '~/hooks/useUserPositions';
-import { divideFnValidOnly } from '~/lib/utils';
+import { divideFnValidOnly, parseToFormattedNumber } from '~/lib/utils';
 
 export interface UsePreviewRemoveLiquidity {
   amountToRemove?: bigint | null;
@@ -16,12 +15,21 @@ export function usePreviewRemoveLiquidity({ amountToRemove }: UsePreviewRemoveLi
 
   const previewDAIRemoved = divideFnValidOnly(amountToRemoveNum * tokenReserve, totalLiquidity);
   const previewETHRemoved = divideFnValidOnly(amountToRemoveNum * ethReserve, totalLiquidity);
-  const formattedPreviewDAIRemoved = formatUnits(Math.floor(previewDAIRemoved), DECIMAL_UNITS);
-  const formattedPreviewETHRemoved = formatUnits(Math.floor(previewETHRemoved), DECIMAL_UNITS);
+  const formattedPreviewDAIRemoved = parseToFormattedNumber(
+    Math.floor(previewDAIRemoved),
+    DECIMAL_UNITS
+  );
+  const formattedPreviewETHRemoved = parseToFormattedNumber(
+    Math.floor(previewETHRemoved),
+    DECIMAL_UNITS
+  );
 
   const nextCurrentPoolTokens = poolTokensNum - amountToRemoveNum;
   const nextPoolShare = nextCurrentPoolTokens / totalLiquidity;
-  const formattedNextCurrentPoolTokens = formatUnits(nextCurrentPoolTokens, DECIMAL_UNITS);
+  const formattedNextCurrentPoolTokens = parseToFormattedNumber(
+    nextCurrentPoolTokens,
+    DECIMAL_UNITS
+  );
   const formattedNextPoolShare = parseFloat((nextPoolShare * 100).toFixed(6));
 
   return {


### PR DESCRIPTION
`Add Liquidity Page`
- removed old `reserves` box
- added `Preview` info
- added new `Current Pool Reserves` info
- format with thousand and decimal separators (make sure show some big numbers better)
- refact in page components structure

Closes #219 
Closes #220 