### PR TITLE
fix: correct behavior when typing only "." in the coin input

### DIFF
--- a/packages/app/src/systems/Core/components/CoinInput.tsx
+++ b/packages/app/src/systems/Core/components/CoinInput.tsx
@@ -168,7 +168,17 @@ export function useCoinInput({
 
 function getRightValue(value: string, displayType: string) {
   if (displayType === "text") return parseToFormattedNumber(value);
-  return value === "0.0" ? "0" : value;
+
+  switch (value) {
+    case "0.0":
+      return "0";
+
+    case ".":
+      return "0.";
+
+    default:
+      return value;
+  }
 }
 
 type CoinInputProps = Omit<UseCoinParams, "onChange"> &

--- a/packages/app/src/systems/Pool/pages/AddLiquidity.test.tsx
+++ b/packages/app/src/systems/Pool/pages/AddLiquidity.test.tsx
@@ -196,4 +196,23 @@ describe("Add Liquidity", () => {
     const successFeedback = await screen.findByText(/New pool created/i);
     expect(successFeedback).toBeInTheDocument();
   });
+
+  it("should show '0.' if typed only '.' in the input", async () => {
+    jest.unmock("../hooks/useUserPositions.ts");
+
+    renderWithRouter(<App />, {
+      route: "/pool/add-liquidity",
+    });
+
+    const coinFromInput = screen.getByLabelText(/Coin From Input/);
+    fireEvent.change(coinFromInput, {
+      target: {
+        value: ".",
+      },
+    });
+
+    await waitFor(() => {
+      expect(coinFromInput).toHaveValue("0.");
+    });
+  });
 });


### PR DESCRIPTION
- addressed bug when typing only "." in the coin input
- created unit test to make sure it's working on the way it's supposed to

Closes #287