### PR TITLE
chore: remove `.vscode` directory

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,0 @@
-{
-  "recommendations": [
-    "esbenp.prettier-vscode",
-    "dbaeumer.vscode-eslint",
-    "FuelLabs.sway-vscode-plugin",
-    "statelyai.stately-vscode"
-  ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "prettier.prettierPath": "./node_modules/prettier",
-  "editor.formatOnSave": true,
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  },
-  "jest.jestCommandLine": "cd packages/app && pnpm jest"
-}


### PR DESCRIPTION
Any local changes to my vscode workspace settings end up modifying the `.vscode/settings.json` file, and I have to carefully make sure I don't commit those changes.

Editor and OS-specific directories and files such as `.vscode/` and `.DS_store` don't belong in source control.