### PR TITLE
fix: reduce images on mobile

### DIFF
--- a/packages/app/src/styles/components/welcome-page.css
+++ b/packages/app/src/styles/components/welcome-page.css
@@ -91,6 +91,10 @@
     }
     img {
       @apply mx-auto mb-5;
+
+      @media (max-width: 640px) {
+        @apply h-[180px];
+      }
     }
   }
   /*

--- a/packages/app/src/styles/components/welcome-page.css
+++ b/packages/app/src/styles/components/welcome-page.css
@@ -93,7 +93,7 @@
       @apply mx-auto mb-5;
 
       @media (max-width: 640px) {
-        @apply h-[180px];
+        @apply max-w-[180px];
       }
     }
   }


### PR DESCRIPTION
Before:
<img width="306" alt="Screen Shot 2022-06-19 at 9 59 57 PM" src="https://user-images.githubusercontent.com/3941923/174507984-ed5cdb59-3dc5-47c0-8e01-76634b1cd93a.png">

Now:
<img width="305" alt="Screen Shot 2022-06-19 at 10 00 06 PM" src="https://user-images.githubusercontent.com/3941923/174508000-da82b891-ac92-418d-ac8b-aff570686c90.png">

