### PR TITLE
chore: remove redundant docs link in header

### DIFF
--- a/packages/app/src/systems/Home/components/Header.tsx
+++ b/packages/app/src/systems/Home/components/Header.tsx
@@ -19,12 +19,6 @@ export function Header() {
         <Link isExternal href="https://github.com/FuelLabs/swayswap">
           Github
         </Link>
-        <Link
-          isExternal
-          href="https://github.com/FuelLabs/swayswap/blob/master/README.md"
-        >
-          Docs
-        </Link>
         <Button
           size={breakpoint === "sm" ? "sm" : "lg"}
           variant="primary"


### PR DESCRIPTION
The docs are for developers, not users, and they're already readily linked-to in the GitHub repo.

Reported by @Braqzen 