### PR TITLE
chore: remove launch app button on home

### DIFF
--- a/packages/app/src/systems/Home/components/HomeHero.tsx
+++ b/packages/app/src/systems/Home/components/HomeHero.tsx
@@ -28,9 +28,6 @@ export function HomeHero() {
         scaling beyond layer-2s and monolithic blockchain design.
         #BeyondMonolithic
       </p>
-      <Button size="lg" variant="primary" onPress={() => navigate(Pages.swap)}>
-        Launch app
-      </Button>
     </div>
   );
 }

--- a/packages/app/src/systems/Home/components/HomeHero.tsx
+++ b/packages/app/src/systems/Home/components/HomeHero.tsx
@@ -1,10 +1,6 @@
-import { useNavigate } from "react-router-dom";
-
-import { Button, Link } from "~/systems/UI";
-import { Pages } from "~/types";
+import { Link } from "~/systems/UI";
 
 export function HomeHero() {
-  const navigate = useNavigate();
   return (
     <div className="homePage--hero">
       <h1>


### PR DESCRIPTION
Fixes #323

Note that this only functionally removes the button, it doesn't change the padding. Therefore, the text looks a bit low. This can be fixed in a subsequent PR (tracked in #326).