### PR TITLE
feat: avoid multiple error notifications

### DIFF
--- a/packages/app/src/systems/Core/utils/queryClient.tsx
+++ b/packages/app/src/systems/Core/utils/queryClient.tsx
@@ -20,6 +20,7 @@ function handleError(error: any) {
   const msg = error.message;
   toast.error(msg.includes("Panic") ? panicError(msg) : msg, {
     duration: 100000000,
+    id: msg,
   });
 }
 


### PR DESCRIPTION
Avoid multiple error notifications using block `msg` as ID of the toast. On this way we only show again if the block `msg` is different.

Closes #334 