### PR TITLE
chore: keep input size when has no balance

### DIFF
--- a/packages/app/src/systems/Core/components/CoinBalance.tsx
+++ b/packages/app/src/systems/Core/components/CoinBalance.tsx
@@ -23,7 +23,7 @@ export const CoinBalance = ({
   }, [balances, coin?.assetId]);
 
   return (
-    <div className="flex items-center justify-end gap-2 mt-2 whitespace-nowrap">
+    <div className="flex items-center justify-end gap-2 mt-2 whitespace-nowrap min-h-[18px]">
       {showBalance && (
         <div
           className="text-xs text-gray-400"


### PR DESCRIPTION
make CoinBalance have a fixed height, to show the same size even when has no balance for that specific coin. Avoiding layout flicks and moving elements

Closes #363 