### PR TITLE
feat: should set input value when has no coin input too

### DIFF
--- a/packages/app/src/systems/Swap/machines/swapMachine.ts
+++ b/packages/app/src/systems/Swap/machines/swapMachine.ts
@@ -295,15 +295,16 @@ export const swapMachine =
         INPUT_CHANGE: [
           {
             actions: 'clearContext',
-            ...INVALID_STATES.NO_COIN_SELECTED,
-          },
-          {
-            actions: 'clearContext',
             cond: 'inputIsEmpty',
             target: '.invalid.withoutAmount',
           },
           {
             actions: 'setInputValue',
+            ...INVALID_STATES.NO_COIN_SELECTED,
+          },
+          {
+            actions: 'setInputValue',
+            cond: 'hasCoinsSelected',
             target: '.debouncing',
           },
         ],
@@ -449,6 +450,9 @@ export const swapMachine =
         },
         notHasCoinSelected: (ctx) => {
           return !ctx.coinFrom || !ctx.coinTo;
+        },
+        hasCoinsSelected: (ctx) => {
+          return ctx.coinFrom && ctx.coinTo;
         },
         notHasAmount: (ctx) => {
           return (

--- a/packages/app/src/systems/Swap/machines/swapMachine.ts
+++ b/packages/app/src/systems/Swap/machines/swapMachine.ts
@@ -452,7 +452,7 @@ export const swapMachine =
           return !ctx.coinFrom || !ctx.coinTo;
         },
         hasCoinsSelected: (ctx) => {
-          return ctx.coinFrom && ctx.coinTo;
+          return Boolean(ctx.coinFrom && ctx.coinTo);
         },
         notHasAmount: (ctx) => {
           return (


### PR DESCRIPTION
When fill coin "from" value before selecting "To" token, swap preview should be calculated after selecting the "To" token (DAI)


https://user-images.githubusercontent.com/8636507/177417901-910b96d0-6a86-49fe-b264-bc490e7e4dd0.mov



Closes #356 