### PR TITLE
feat: should disable max button instead of hiding

### DIFF
--- a/packages/app/src/systems/Core/components/CoinBalance.tsx
+++ b/packages/app/src/systems/Core/components/CoinBalance.tsx
@@ -23,7 +23,7 @@ export const CoinBalance = ({
   }, [balances, coin?.assetId]);
 
   return (
-    <div className="flex items-center justify-end gap-2 mt-2 whitespace-nowrap">
+    <div className="flex items-center justify-end gap-2 mt-2 whitespace-nowrap min-h-[18px]">
       {showBalance && (
         <div
           className="text-xs text-gray-400"

--- a/packages/app/src/systems/Swap/hooks/useSwapMaxButton.tsx
+++ b/packages/app/src/systems/Swap/hooks/useSwapMaxButton.tsx
@@ -68,7 +68,7 @@ export function useSwapMaxButton(direction: SwapDirection): CoinSelectorProps {
     coin,
     gasFee,
     showBalance: Boolean(hasBalance),
-    showMaxButton: Boolean(hasBalance),
+    showMaxButton: Boolean(hasBalance) && isFrom,
     onSetMaxBalance: () => {
       send("SET_MAX_VALUE", { data: { direction } });
     },

--- a/packages/app/src/systems/Swap/pages/SwapPage.test.tsx
+++ b/packages/app/src/systems/Swap/pages/SwapPage.test.tsx
@@ -256,17 +256,5 @@ describe("SwapPage", () => {
         expect(maxBalanceBtn.getAttribute("aria-disabled")).toEqual("true");
       });
     });
-
-    it("should disable max button after setting max TO balance", async () => {
-      renderWithRouter(<App />, { route: "/swap?from=ETH&to=DAI" });
-
-      await waitFinishLoading();
-      await clickOnMaxBalance("to");
-
-      await waitFor(async () => {
-        const maxBalanceBtn = await findMaxBalanceBtn("to");
-        expect(maxBalanceBtn.getAttribute("aria-disabled")).toEqual("true");
-      });
-    });
   });
 });

--- a/packages/app/src/systems/Swap/pages/SwapPage.test.tsx
+++ b/packages/app/src/systems/Swap/pages/SwapPage.test.tsx
@@ -250,7 +250,6 @@ describe("SwapPage", () => {
 
       await waitFinishLoading();
       await clickOnMaxBalance();
-      await waitFinishLoading();
 
       await waitFor(async () => {
         const maxBalanceBtn = await findMaxBalanceBtn();
@@ -263,7 +262,6 @@ describe("SwapPage", () => {
 
       await waitFinishLoading();
       await clickOnMaxBalance("to");
-      await waitFinishLoading();
 
       await waitFor(async () => {
         const maxBalanceBtn = await findMaxBalanceBtn("to");

--- a/packages/app/src/systems/Swap/pages/SwapPage.test.tsx
+++ b/packages/app/src/systems/Swap/pages/SwapPage.test.tsx
@@ -50,6 +50,18 @@ async function fillCoinFromWithValue(value: string) {
   });
 }
 
+async function waitFinishLoading() {
+  await waitFor(async () => {
+    const submitBtn = await findSwapBtn();
+    expect(submitBtn.textContent).toMatch(/Loading/i);
+  });
+
+  await waitFor(async () => {
+    const submitBtn = await findSwapBtn();
+    expect(submitBtn.textContent).not.toMatch(/Loading/i);
+  });
+}
+
 describe("SwapPage", () => {
   let wallet: Wallet;
 
@@ -236,29 +248,21 @@ describe("SwapPage", () => {
     it("should disable max button after setting max FROM balance", async () => {
       renderWithRouter(<App />, { route: "/swap?from=ETH&to=DAI" });
 
+      await waitFinishLoading();
       await clickOnMaxBalance();
-
-      await waitFor(async () => {
-        const submitBtn = await findSwapBtn();
-        expect(submitBtn.textContent).toMatch(/Loading/i);
-      });
-
+      await waitFinishLoading();
       await waitFor(async () => {
         const maxBalanceBtn = await findMaxBalanceBtn();
         expect(maxBalanceBtn.getAttribute("aria-disabled")).toEqual("true");
       });
     });
 
-    it("should disable max button after setting max FROM balance", async () => {
+    it("should disable max button after setting max TO balance", async () => {
       renderWithRouter(<App />, { route: "/swap?from=ETH&to=DAI" });
 
+      await waitFinishLoading();
       await clickOnMaxBalance("to");
-
-      await waitFor(async () => {
-        const submitBtn = await findSwapBtn();
-        expect(submitBtn.textContent).toMatch(/Loading/i);
-      });
-
+      await waitFinishLoading();
       await waitFor(async () => {
         const maxBalanceBtn = await findMaxBalanceBtn("to");
         expect(maxBalanceBtn.getAttribute("aria-disabled")).toEqual("true");

--- a/packages/app/src/systems/Swap/pages/SwapPage.test.tsx
+++ b/packages/app/src/systems/Swap/pages/SwapPage.test.tsx
@@ -251,6 +251,7 @@ describe("SwapPage", () => {
       await waitFinishLoading();
       await clickOnMaxBalance();
       await waitFinishLoading();
+
       await waitFor(async () => {
         const maxBalanceBtn = await findMaxBalanceBtn();
         expect(maxBalanceBtn.getAttribute("aria-disabled")).toEqual("true");
@@ -263,6 +264,7 @@ describe("SwapPage", () => {
       await waitFinishLoading();
       await clickOnMaxBalance("to");
       await waitFinishLoading();
+
       await waitFor(async () => {
         const maxBalanceBtn = await findMaxBalanceBtn("to");
         expect(maxBalanceBtn.getAttribute("aria-disabled")).toEqual("true");


### PR DESCRIPTION
In Swap page, stop hiding max button, only disable instead.

Now when we refresh the page, there's no blinking in the "max" button, making it look smoother


https://user-images.githubusercontent.com/8636507/177425354-e68ecadd-7054-4f8d-816b-e942a1a49a4d.mov


Closes #362 