### PR TITLE
Fixed contracts errors

### DIFF
--- a/packages/contracts/swayswap_contract/src/main.sw
+++ b/packages/contracts/swayswap_contract/src/main.sw
@@ -5,16 +5,20 @@ use swayswap_helpers::{store_b256, get_b256};
 
 abi SwapSwap {
     // Add exchange contract to the token
+    #[storage(write)]
     fn add_exchange_contract(token_id: ContractId, exchange_id: ContractId);
     // Get exchange contract for desired token
+    #[storage(read)]
     fn get_exchange_contract(token_id: ContractId) -> ContractId;
 }
 
 impl SwapSwap for Contract {
+    #[storage(write)]
     fn add_exchange_contract(token_id: ContractId, exchange_id: ContractId) {
         // TODO: Assert exchange contract binary to avoid non exchange contracts to be saved
         store_b256(token_id.into(), exchange_id.into());
     }
+    #[storage(read)]
     fn get_exchange_contract(token_id: ContractId) -> ContractId {
         ~ContractId::from(get_b256(token_id.into()))
     }

--- a/packages/contracts/swayswap_helpers/src/main.sw
+++ b/packages/contracts/swayswap_helpers/src/main.sw
@@ -10,6 +10,7 @@ use std::{
     identity::Identity,
 };
 
+#[storage(read)]
 pub fn get_b256(key: b256) -> b256 {
     asm(r1: key, r2) {
         move r2 sp;
@@ -20,6 +21,7 @@ pub fn get_b256(key: b256) -> b256 {
 }
 
 // Store b256 values on memory
+#[storage(write)]
 pub fn store_b256(key: b256, value: b256) {
     asm(r1: key, r2: value) {
         swwq r1 r2;

--- a/packages/contracts/token_contract/src/main.sw
+++ b/packages/contracts/token_contract/src/main.sw
@@ -2,7 +2,7 @@ contract;
 
 use std::{
     address::*,
-    assert::require,
+    revert::require,
     context::{*, call_frames::*},
     contract_id::ContractId,
     storage::*,


### PR DESCRIPTION
Fixed an import error of `require` caused by the new release. Fixed absence of storage read and write attributes. Now contracts are compatible with the latest release of force version `20.2`.